### PR TITLE
fix: remove matplotlib.use('Agg') from test notebook

### DIFF
--- a/test/test_notebook.ipynb
+++ b/test/test_notebook.ipynb
@@ -1,130 +1,130 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "cell-markdown-intro",
-      "metadata": {},
-      "source": [
-        "# ipynb test notebook\n",
-        "\n",
-        "Testing **all phases** of the plugin.\n",
-        "\n",
-        "- Phase 1: open, navigate, edit, save\n",
-        "- Phase 2: kernel execution, text output\n",
-        "- Phase 3: image/plot rendering\n",
-        "- Phase 4: markdown rendering, completions, inspector"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-phase1-test",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Phase 1 test — basic Python\n",
-        "print('Hello from ipynb!')\n",
-        "x = 42\n",
-        "print(f'x = {x}')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-phase2-text",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Phase 2 test — stdout, stderr, result\n",
-        "import sys\n",
-        "\n",
-        "print('stdout line 1')\n",
-        "print('stdout line 2')\n",
-        "print('stderr line', file=sys.stderr)\n",
-        "\n",
-        "# This produces a result\n",
-        "1 + 1"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-phase2-error",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Phase 2 test — error output\n",
-        "raise ValueError('intentional test error')"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-phase3-plot",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Phase 3 test — matplotlib plot (requires image.nvim)\n",
-        "import matplotlib\n",
-        "matplotlib.use('Agg')  # non-interactive backend\n",
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "\n",
-        "x = np.linspace(0, 2 * np.pi, 200)\n",
-        "plt.figure(figsize=(6, 3))\n",
-        "plt.plot(x, np.sin(x), label='sin(x)')\n",
-        "plt.plot(x, np.cos(x), label='cos(x)')\n",
-        "plt.legend()\n",
-        "plt.title('ipynb image test')\n",
-        "plt.tight_layout()\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-phase4-inspect",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Phase 4 test — variables for inspector\n",
-        "import numpy as np\n",
-        "\n",
-        "my_array  = np.arange(100).reshape(10, 10)\n",
-        "my_list   = list(range(20))\n",
-        "my_string = 'hello ipynb'\n",
-        "my_dict   = {'a': 1, 'b': 2, 'c': 3}\n",
-        "\n",
-        "print('Variables created. Press <leader>ji to open the inspector.')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cell-markdown-end",
-      "metadata": {},
-      "source": [
-        "## Done\n",
-        "\n",
-        "If you can see:\n",
-        "- `╭─ [py] python ─╮` borders around each cell\n",
-        "- Output rendered inline below each cell after `<leader>r`\n",
-        "- This markdown rendered with **bold**, *italic*, and `code`\n",
-        "\n",
-        "Then the plugin is working correctly."
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.12.3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-markdown-intro",
+   "metadata": {},
+   "source": [
+    "# ipynb test notebook\n",
+    "\n",
+    "Testing **all phases** of the plugin.\n",
+    "\n",
+    "- Phase 1: open, navigate, edit, save\n",
+    "- Phase 2: kernel execution, text output\n",
+    "- Phase 3: image/plot rendering\n",
+    "- Phase 4: markdown rendering, completions, inspector"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-phase1-test",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Phase 1 test \u2014 basic Python\n",
+    "print('Hello from ipynb!')\n",
+    "x = 42\n",
+    "print(f'x = {x}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-phase2-text",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Phase 2 test \u2014 stdout, stderr, result\n",
+    "import sys\n",
+    "\n",
+    "print('stdout line 1')\n",
+    "print('stdout line 2')\n",
+    "print('stderr line', file=sys.stderr)\n",
+    "\n",
+    "# This produces a result\n",
+    "1 + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-phase2-error",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Phase 2 test \u2014 error output\n",
+    "raise ValueError('intentional test error')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-phase3-plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Phase 3 test - matplotlib plot (requires image.nvim)\n",
+    "# %matplotlib inline is auto-configured by the kernel on start.\n",
+    "# Do NOT call matplotlib.use() here - it overrides the inline backend.\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "x = np.linspace(0, 2 * np.pi, 200)\n",
+    "plt.figure(figsize=(6, 3))\n",
+    "plt.plot(x, np.sin(x), label='sin(x)')\n",
+    "plt.plot(x, np.cos(x), label='cos(x)')\n",
+    "plt.legend()\n",
+    "plt.title('ipynb image test')\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-phase4-inspect",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Phase 4 test \u2014 variables for inspector\n",
+    "import numpy as np\n",
+    "\n",
+    "my_array  = np.arange(100).reshape(10, 10)\n",
+    "my_list   = list(range(20))\n",
+    "my_string = 'hello ipynb'\n",
+    "my_dict   = {'a': 1, 'b': 2, 'c': 3}\n",
+    "\n",
+    "print('Variables created. Press <leader>ji to open the inspector.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-markdown-end",
+   "metadata": {},
+   "source": [
+    "## Done\n",
+    "\n",
+    "If you can see:\n",
+    "- `\u256d\u2500 [py] python \u2500\u256e` borders around each cell\n",
+    "- Output rendered inline below each cell after `<leader>r`\n",
+    "- This markdown rendered with **bold**, *italic*, and `code`\n",
+    "\n",
+    "Then the plugin is working correctly."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary

- The Phase 3 test cell in `test/test_notebook.ipynb` had `matplotlib.use('Agg')` hardcoded. This explicitly forced the non-interactive Agg backend and directly overrode the `%matplotlib inline` auto-configuration added in #19/#20. The result was the `FigureCanvasAgg is non-interactive` warning on every `plt.show()` call, regardless of the kernel setup fix.

- Removed `import matplotlib` and `matplotlib.use('Agg')` from the test cell. Added a comment explaining that `%matplotlib inline` is auto-configured by the kernel and must not be overridden.

## Test plan

- [ ] Run the Phase 3 matplotlib cell in the test notebook - plot should render as an inline image, no FigureCanvasAgg warning
- [ ] Verify `%matplotlib inline` is the only backend configuration (no explicit `matplotlib.use()` call in the cell)