### PR TITLE
fix: replace lua@5.1 with luajit for macOS magick install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ rendering, full Vim modal editing, live kernel execution, and inline output.
 - `luarocks` + `magick` luarock + `imagemagick` system library (required by image.nvim)
 
 ```bash
-# macOS — lua@5.1 is required so luarocks targets Neovim's LuaJIT runtime.
-# Do NOT pin version 1.0.0-1: it only supports ImageMagick 6.
-# Omitting the version installs the latest rock, which supports ImageMagick 7.
-brew install luarocks imagemagick lua@5.1
-luarocks --local --lua-dir=$(brew --prefix lua@5.1) install magick
+# macOS — use luajit (lua@5.1 was removed from Homebrew).
+# Neovim uses LuaJIT which is Lua 5.1 compatible.
+# Do NOT pin magick 1.0.0-1: it only supports ImageMagick 6.
+brew install luarocks imagemagick luajit
+luarocks --local --lua-dir=$(brew --prefix luajit) --lua-version=5.1 install magick
 ```
 
 **Optional - richer markdown cells**
@@ -100,7 +100,7 @@ return {
       "nvim-treesitter/nvim-treesitter",
       {
         "3rd/image.nvim",
-        build = "luarocks --local --lua-dir=$(brew --prefix lua@5.1) install magick",
+        build = "luarocks --local --lua-dir=$(brew --prefix luajit) --lua-version=5.1 install magick",
         opts = {
           backend = "kitty",              -- "kitty" for Kitty/Ghostty/WezTerm
           -- backend = "ueberzugpp",      -- for iTerm2 / other terminals


### PR DESCRIPTION
## Summary

- lua@5.1 was removed from Homebrew and is no longer available
- Neovim uses LuaJIT (Lua 5.1 compatible runtime), so luajit is the correct formula
- Updated luarocks command to use --lua-dir=$(brew --prefix luajit) --lua-version=5.1
- Updated image.nvim build hook in lazy.nvim snippet to match

## Test plan

- [ ] On macOS: brew install luarocks imagemagick luajit succeeds
- [ ] luarocks --local --lua-dir=$(brew --prefix luajit) --lua-version=5.1 install magick installs without error
- [ ] :checkhealth image in Neovim shows magick found
- [ ] matplotlib plots render inline in a kitty/Ghostty/WezTerm terminal