### PR TITLE
docs: add tmux allow-passthrough requirement for image rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ rendering, full Vim modal editing, live kernel execution, and inline output.
 - [3rd/image.nvim](https://github.com/3rd/image.nvim)
 - Kitty, Ghostty, or WezTerm terminal (Kitty graphics protocol), or `ueberzugpp` for others
 - `luarocks` + `magick` luarock + `imagemagick` system library (required by image.nvim)
+- **tmux users:** add `set -g allow-passthrough on` to `~/.tmux.conf` and restart tmux, otherwise image.nvim will error on startup
 
 ```bash
 # macOS — use luajit (lua@5.1 was removed from Homebrew).


### PR DESCRIPTION
## Summary

- image.nvim errors on startup inside tmux unless allow-passthrough is enabled
- Added note to the image rendering requirements section with the fix

## Test plan

- [ ] README renders correctly on GitHub
- [ ] tmux users: add allow-passthrough, restart tmux, confirm no image.nvim startup error