### PR TITLE
docs: add Linux luarocks/magick install instructions for image rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ brew install luarocks imagemagick luajit
 luarocks --local --lua-dir=$(brew --prefix luajit) --lua-version=5.1 install magick
 ```
 
+```bash
+# Linux (Debian/Ubuntu)
+sudo apt install luarocks libmagickwand-dev
+luarocks --local --lua-version=5.1 install magick
+```
+
 **Optional - richer markdown cells**
 
 - [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim)


### PR DESCRIPTION
## Summary

- Plugin works on both macOS and Linux but the README only showed macOS install steps for the magick luarock
- Added Debian/Ubuntu snippet alongside the existing macOS one

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Linux user can follow the snippet and get image rendering working