### PR TITLE
fix: attach LSP clients when opening a notebook buffer

### DIFF
--- a/lua/ipynb/notebook_buf.lua
+++ b/lua/ipynb/notebook_buf.lua
@@ -56,6 +56,44 @@ local function set_buf_name(bufnr, path)
   vim.api.nvim_buf_set_var(bufnr, "ipynb_path", path)
 end
 
+-- ── LSP attachment ───────────────────────────────────────────────────────────
+
+--- Attach Python LSP clients to the notebook buffer.
+---
+--- The buffer is opened via BufReadCmd, which bypasses the normal file-open
+--- path that triggers FileType autocmds with a valid buffer name.  Two
+--- strategies together cover the common cases:
+---
+---   1. Re-fire "FileType python" via nvim_exec_autocmds.  This bypasses the
+---      "filetype unchanged" guard so the event fires even though filetype is
+---      already "python".  nvim-lspconfig, ruff-lsp, and Copilot all hook into
+---      this event, so they will see the correct buffer name and attach.
+---
+---   2. Directly attach any Python LSP client that is already running (e.g.
+---      started from a .py file that was open before this notebook).
+---
+---@param bufnr integer
+local function attach_lsp(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then return end
+
+  -- Strategy 1: re-fire FileType so lspconfig autostart logic runs.
+  vim.api.nvim_exec_autocmds("FileType", { buffer = bufnr, match = "python" })
+
+  -- Strategy 2: attach any already-running Python LSP client.
+  local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  for _, client in ipairs(get_clients()) do
+    if vim.lsp.buf_is_attached(bufnr, client.id) then goto continue end
+    local fts = (client.config or {}).filetypes or {}
+    for _, ft in ipairs(fts) do
+      if ft == "python" then
+        pcall(vim.lsp.buf_attach_client, bufnr, client.id)
+        break
+      end
+    end
+    ::continue::
+  end
+end
+
 -- ── Sync: buffer → notebook model ────────────────────────────────────────────
 
 --- Walk all cells and sync their current buffer content back into
@@ -197,6 +235,13 @@ function M.open(path, bufnr)
       if ok then kernel.start(bufnr, nil) end
     end)
   end
+
+  -- Attach LSP clients (pyright, pylsp, ruff-lsp, Copilot, etc.).
+  -- Deferred so the buffer name and filetype are fully committed before
+  -- lspconfig root_dir detection runs.
+  vim.schedule(function()
+    attach_lsp(bufnr)
+  end)
 
   -- Mark buffer as not modified after initial load.
   vim.api.nvim_buf_set_option(bufnr, "modified", false)


### PR DESCRIPTION
## Summary

- `BufReadCmd` intercepts the normal file open, so `FileType python` fires before the buffer name is set. `nvim-lspconfig` root_dir detection sees no valid path and refuses to attach.
- `cell.render()` re-sets `filetype = "python"` later, but Neovim skips the `FileType` event when the value hasn't changed - so LSP still doesn't attach.
- Add `attach_lsp(bufnr)` called via `vim.schedule` after all setup is complete (name set, filetype set, content rendered):
  1. Re-fires `FileType python` with `nvim_exec_autocmds`, bypassing the unchanged-value guard. `nvim-lspconfig`, `ruff-lsp`, and Copilot all hook into this event and now see the correct buffer path.
  2. Directly calls `vim.lsp.buf_attach_client` for any Python LSP client already running (e.g. started from a `.py` file open before the notebook), so completions and diagnostics work immediately without needing to open another Python file first.

## Test plan

- [ ] Open `test/test_notebook.ipynb` with pyright or pylsp configured via nvim-lspconfig
- [ ] Hover over a variable with `K` - should show LSP documentation
- [ ] Trigger completions with `<C-x><C-o>` or nvim-cmp - LSP completions should appear alongside kernel completions
- [ ] Check `:LspInfo` - should show the Python LSP attached to the notebook buffer
- [ ] Open a `.py` file first to start the LSP, then open the notebook - LSP should attach immediately (strategy 2)
- [ ] Check `:messages` for Lua errors