### PR TITLE
fix: use pattern= not match= in nvim_exec_autocmds for FileType

### DIFF
--- a/lua/ipynb/notebook_buf.lua
+++ b/lua/ipynb/notebook_buf.lua
@@ -77,7 +77,11 @@ local function attach_lsp(bufnr)
   if not vim.api.nvim_buf_is_valid(bufnr) then return end
 
   -- Strategy 1: re-fire FileType so lspconfig autostart logic runs.
-  vim.api.nvim_exec_autocmds("FileType", { buffer = bufnr, match = "python" })
+  -- nvim_exec_autocmds does not accept "match"; use "pattern" (the autocmd
+  -- pattern to match against).  "buffer" and "pattern" are mutually exclusive
+  -- in this API, so omit "buffer" - lspconfig reads the current buffer when
+  -- the FileType event fires, which is the notebook buffer at this point.
+  vim.api.nvim_exec_autocmds("FileType", { pattern = "python" })
 
   -- Strategy 2: attach any already-running Python LSP client.
   local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients


### PR DESCRIPTION
## Summary

- `nvim_exec_autocmds` does not accept a `match` key — valid keys are `group`, `pattern`, `buffer`, `modeline`, `data`
- The invalid key caused an immediate error on every notebook open: `Error executing vim.schedule lua callback: invalid key: match`
- Also: `buffer` and `pattern` are mutually exclusive in this API, so drop `buffer` and use `pattern = "python"` only
- lspconfig reads `nvim_get_current_buf()` when `FileType` fires, which is the notebook buffer at the point `attach_lsp` runs inside `vim.schedule`

## Test plan

- [ ] Open `test/test_notebook.ipynb` — no error in `:messages`
- [ ] Confirm LSP still attaches (`:LspInfo` shows the Python client on the notebook buffer)