### PR TITLE
fix: kernel_bridge.py not found after folder restructure

### DIFF
--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -61,9 +61,9 @@ end
 --- Works for both local dev trees and lazy.nvim installs.
 ---@return string
 local function bridge_path()
-  -- debug.getinfo(1).source == "@/abs/path/lua/ipynb/kernel.lua"
+  -- source is lua/ipynb/kernel/init.lua; :h:h:h:h walks to plugin root
   local this_file = debug.getinfo(1, "S").source:sub(2)
-  local root = vim.fn.fnamemodify(this_file, ":h:h:h")
+  local root = vim.fn.fnamemodify(this_file, ":h:h:h:h")
   return root .. "/python/kernel_bridge.py"
 end
 


### PR DESCRIPTION
## Summary

- `bridge_path()` in `kernel/init.lua` was using `:h:h:h` to walk up to the plugin root, which was correct when the file lived at `lua/ipynb/kernel.lua` (2 levels deep)
- After the refactor the file moved to `lua/ipynb/kernel/init.lua` (3 levels deep), so `:h:h:h` now resolves to `lua/` instead of the plugin root
- Fix: use `:h:h:h:h` to walk four levels up

**Wrong path (before):** `.../ipynb.nvim/lua/python/kernel_bridge.py`
**Correct path (after):** `.../ipynb.nvim/python/kernel_bridge.py`

## Test plan

- [ ] Install plugin via lazy.nvim on macOS
- [ ] Open a `.ipynb` file - kernel should start without the `kernel_bridge.py not found` error
- [ ] Run a cell and confirm output appears