### PR TITLE
fix: wire auto_save and improve kernel crash notification

### DIFF
--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -278,13 +278,16 @@ local function spawn_bridge(bufnr)
         st.pending = {}
 
         if was_starting then
-          utils.err(string.format(
-            "Kernel failed to start (exit %d). Check :messages for details.", code
-          ))
+          utils.err(
+            string.format("Kernel failed to start (exit %d). Check :messages for details.", code)
+          )
         else
-          utils.err(string.format(
-            "Kernel stopped unexpectedly (exit %d). Run :IpynbKernelRestart to recover.", code
-          ))
+          utils.err(
+            string.format(
+              "Kernel stopped unexpectedly (exit %d). Run :IpynbKernelRestart to recover.",
+              code
+            )
+          )
         end
       end
     end,


### PR DESCRIPTION
## Summary

- **Fix #64** - `notebook.auto_save` was a no-op. The config key existed but nothing read it. Now `dispatch` in `kernel/init.lua` calls `nb_buf.save()` via `vim.schedule` after each cell execution completes (when status transitions to idle). Triggered only when `notebook.auto_save = true` (default is false, no behaviour change for existing users).

- **Fix #65** - Kernel crash gave no actionable feedback and left running cells stuck in "busy" state forever. Changes:
  - `M.stop()` now sets `s.status = "stopped"` before sending shutdown, so `on_exit` can tell the difference between a user-requested stop and an unexpected exit
  - `on_exit` checks `was_unexpected` (status was not "stopped") and on unexpected exit: marks all pending cells as errored, clears the pending table, and prints a clear error message with `:IpynbKernelRestart` guidance
  - Startup failures (`was_starting`) get a distinct message pointing to `:messages`

## Test plan

- [ ] Set `notebook = { auto_save = true }` in setup, run a cell, verify the .ipynb file is updated on disk after execution
- [ ] Default config (`auto_save = false`): run a cell, verify no automatic save
- [ ] Kill the kernel process externally (`kill <pid>`), verify error notification appears and pending cells show error status
- [ ] Run `:IpynbKernelRestart` after a crash, verify the kernel restarts cleanly
- [ ] Normal `:IpynbKernelStop` still works without showing an error