### PR TITLE
fix(lua): add 16px transparent gap between stacked images

### DIFF
--- a/lua/ipynb/ui/image.lua
+++ b/lua/ipynb/ui/image.lua
@@ -110,9 +110,19 @@ local function combine_vertical(tmps)
     return tmps[1], false
   end
   local out = vim.fn.tempname() .. ".png"
+  -- Add 16px of transparent padding below every image except the last so
+  -- stacked plots are visually separated.  Transparent pixels render as the
+  -- terminal background colour in Kitty, giving a natural gap on any theme.
   local args = {}
-  for _, t in ipairs(tmps) do
-    args[#args + 1] = vim.fn.shellescape(t)
+  for i, t in ipairs(tmps) do
+    if i < #tmps then
+      args[#args + 1] = string.format(
+        "\\( %s -background none -gravity South -splice 0x16 \\)",
+        vim.fn.shellescape(t)
+      )
+    else
+      args[#args + 1] = vim.fn.shellescape(t)
+    end
   end
   local cmd = string.format(
     "convert %s -append %s 2>/dev/null",


### PR DESCRIPTION
## Summary

- `combine_vertical()` was joining images with `-append` flush against each other - no visible separation between plots.
- Add 16 px of transparent bottom padding to every image except the last via ImageMagick `-gravity South -splice 0x16` before the `-append` step.
- Transparent pixels render as the terminal background colour in Kitty, so the gap looks natural on both light and dark themes.

## Test plan

- [ ] Execute the multi-plot test cell (3x `plt.show()`) - each of the 3 plots should have a visible gap between them
- [ ] Verify the gap looks correct on both dark and light terminal backgrounds
- [ ] Single-image cells are unaffected (no change to the single-image path)

Closes #108