### PR TITLE
fix(lua): skip image re-render when screen row unchanged

### DIFF
--- a/lua/ipynb/ui/image.lua
+++ b/lua/ipynb/ui/image.lua
@@ -335,6 +335,7 @@ function M.render_stacked(bufnr, cell_state, chunks)
         end_row = end_row,
         img_index = 0,
         img_height = img_height,
+        last_y = nil, -- not yet rendered; rerender_all will set it on first draw
         source_win = source_win,
       }
       return true
@@ -372,6 +373,7 @@ function M.render_stacked(bufnr, cell_state, chunks)
     end_row = end_row,
     img_index = 0,
     img_height = img_height,
+    last_y = sep_row, -- track rendered position to skip no-op rerenders
     source_win = source_win,
   }
 
@@ -452,6 +454,7 @@ function M.rerender_all(bufnr)
         })
         if ok_from then
           entry.img = img2
+          entry.last_y = y
           pcall(function()
             img2:render()
           end)
@@ -459,7 +462,13 @@ function M.rerender_all(bufnr)
         goto next_entry
       end
 
-      -- Live image: re-render to update position after scroll.
+      -- Live image: only re-render when the screen row actually changed.
+      -- Skipping no-op renders avoids sending Kitty graphics protocol sequences
+      -- that interrupt the cursor animation and cause visible flicker on [[/]].
+      if y == entry.last_y then
+        goto next_entry
+      end
+      entry.last_y = y
       pcall(function()
         entry.img:render()
       end)


### PR DESCRIPTION
## Summary

- `rerender_all()` was calling `img:render()` on every `WinScrolled` event even when the image's y position had not actually changed.
- Each `render()` call sends Kitty graphics protocol sequences that interrupt the cursor blink animation, causing visible cursor jumps when navigating with `[[`/`]]`.
- Fix: track `last_y` per registry entry. Skip `img:render()` when the computed `y` equals `last_y`. Update `last_y` whenever a render actually fires (initial draw, retry after off-screen, and genuine position change).

## Test plan

- [ ] Open a notebook and execute a matplotlib cell to render an image
- [ ] Navigate between cells with `[[` / `]]` - cursor animation should no longer flicker/jump
- [ ] Scroll the notebook manually - image should still reposition correctly when its row changes
- [ ] Images that were off-screen should still appear when scrolled into view

Closes #109