### PR TITLE
fix: disable undo during render() to prevent buffer corruption

### DIFF
--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -201,6 +201,17 @@ function M.render(bufnr, notebook)
   vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
   vim.api.nvim_buf_set_option(bufnr, "readonly", false)
 
+  -- Make all nvim_buf_set_lines calls in this function undo-invisible.
+  -- Neovim's undo system has no concept of cells; render() rewrites the entire
+  -- buffer and each set_lines call would otherwise become its own undo entry.
+  -- Undoing to those entries produces empty buffers, borders without source, or
+  -- mixed content from two render cycles - none of which the plugin can recover.
+  -- Setting undolevels = -1 prevents any of these writes from entering the undo
+  -- tree. The value is restored before the function returns so that in-cell
+  -- typing the user does after this render remains fully undoable.
+  local saved_ul = vim.api.nvim_buf_get_option(bufnr, "undolevels")
+  vim.api.nvim_buf_set_option(bufnr, "undolevels", -1)
+
   -- Clear everything.
   vim.api.nvim_buf_clear_namespace(bufnr, NS, 0, -1)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
@@ -278,6 +289,10 @@ function M.render(bufnr, notebook)
 
   -- Lock filetype for syntax highlighting.
   vim.api.nvim_buf_set_option(bufnr, "filetype", "python")
+
+  -- All buffer line writes are complete. Restore undo tracking so that
+  -- in-cell editing after this render is undoable.
+  vim.api.nvim_buf_set_option(bufnr, "undolevels", saved_ul)
 
   -- Apply markdown decorations after all cells are placed.
   -- Deferred so extmark positions are stable before markdown.render() reads them.


### PR DESCRIPTION
## Summary

- Set `undolevels = -1` at the start of `M.render()` in `cell.lua` and restore it after all `nvim_buf_set_lines` calls complete
- Prevents render()'s buffer rewrites from entering Neovim's undo tree
- In-cell typing after the render remains fully undoable with `u`
- Covers all 8 call sites of `render()`: open, add_cell_below, add_cell_above, delete_cell, WinResized, check_structural_integrity (x2), notebook_buf.open

**Root cause:** `render()` rebuilds the entire buffer from scratch. Each `nvim_buf_set_lines` call created its own undo entry for an intermediate state (empty buffer after clear-all, partial cell write, separator-only buffer) that the plugin's Lua state had no way to recover from. Pressing `u` could land on any of those entries, producing: empty buffer, borders without source, source without borders, or content from two render cycles merged together.

**Trade-off:** `u` can no longer undo structural operations (add_cell, delete_cell, notebook open) at the buffer level. These were never meaningful undo targets - they were programmatic rebuilds. The corruption they caused was the actual bug.

## Test plan

- [ ] Open a notebook, type in a cell, press `u` repeatedly - only typed characters undo, buffer never goes empty or shows raw borders
- [ ] Add a cell (`<leader>co`), type in it, press `u` - only the new typing undoes, no buffer corruption
- [ ] Delete a cell (`<leader>cd`), press `u` - no corruption (cell is gone, as expected for structural ops)
- [ ] Open notebook with existing outputs, press `u` - outputs and borders remain stable
- [ ] Rapid `u` mashing - buffer never reaches empty or broken state