### PR TITLE
feat: split cell at cursor and merge cell with below

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ Press `<leader>jh` to show the help overlay at any time.
 | `:IpynbCellDelete` | Delete current cell |
 | `:IpynbCellAddMarkdown` | Add markdown cell below |
 | `:IpynbCellAddMarkdownAbove` | Add markdown cell above |
+| `:IpynbCellMoveUp` | Move current cell up |
+| `:IpynbCellMoveDown` | Move current cell down |
+| `:IpynbCellDuplicate` | Duplicate current cell below |
+| `:IpynbCellYank` | Yank cell into cell register |
+| `:IpynbCellPaste` | Paste yanked cell below |
+| `:IpynbCellToggleType` | Toggle cell type (code/markdown) |
+| `:IpynbCellSplit` | Split cell at cursor line |
+| `:IpynbCellMerge` | Merge cell with the cell below |
 | `:IpynbClearOutput` | Clear output for cell under cursor |
 | `:IpynbClearAllOutput` | Clear output for every cell |
 | `:IpynbInspect` | Open variable inspector |
@@ -263,6 +271,14 @@ require("ipynb").setup({
     clear_all_output    = "<leader>cX",
     add_markdown_below  = "<leader>mo",
     add_markdown_above  = "<leader>mO",
+    move_cell_up        = "<leader>ck",
+    move_cell_down      = "<leader>cj",
+    duplicate_cell      = "<leader>cc",
+    yank_cell           = "<leader>cy",
+    paste_cell          = "<leader>cv",
+    toggle_cell_type    = "<leader>ct",
+    split_cell          = "<leader>cs",
+    merge_cell          = "<leader>cm",
   },
   notebook = {
     auto_save = false,

--- a/lua/ipynb/config.lua
+++ b/lua/ipynb/config.lua
@@ -53,6 +53,8 @@ local M = {}
 ---@field yank_cell string
 ---@field paste_cell string
 ---@field toggle_cell_type string
+---@field split_cell string
+---@field merge_cell string
 
 ---@class ImageConfig
 ---@field enabled boolean          Enable image rendering (requires snacks.nvim + unicode placeholder terminal)
@@ -124,6 +126,8 @@ M.defaults = {
     yank_cell = "<leader>cy",
     paste_cell = "<leader>cv",
     toggle_cell_type = "<leader>ct",
+    split_cell = "<leader>cs",
+    merge_cell = "<leader>cm",
   },
 
   image = {

--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -767,6 +767,125 @@ function M.toggle_cell_type(bufnr, idx)
   end)
 end
 
+--- Split the cell at `idx` at the current cursor line into two cells of the
+--- same type.  The upper cell keeps lines above the cursor, the lower cell
+--- gets lines from the cursor down.
+---@param bufnr integer
+---@param idx integer
+function M.split_cell(bufnr, idx)
+  local state = get_state(bufnr)
+  local notebook = state.notebook
+  if not notebook then
+    return
+  end
+
+  local cs = state.cells[idx]
+  if not cs then
+    return
+  end
+
+  -- Determine the split line relative to the cell start.
+  local s, e = cell_line_range(bufnr, cs)
+  local cur_row = vim.api.nvim_win_get_cursor(0)[1] - 1 -- 0-based
+  local rel = cur_row - s -- 0-based offset within the cell
+
+  local all_lines = vim.api.nvim_buf_get_lines(bufnr, s, e + 1, false)
+  if rel < 0 then
+    rel = 0
+  end
+  if rel > #all_lines then
+    rel = #all_lines
+  end
+
+  local upper_lines = vim.list_slice(all_lines, 1, rel)
+  local lower_lines = vim.list_slice(all_lines, rel + 1)
+
+  -- Update the original cell's source and clear its outputs.
+  local c = notebook.cells[idx]
+  c.source = table.concat(upper_lines, "\n")
+  c.outputs = c.cell_type == "code" and {} or nil
+  c.execution_count = nil
+
+  -- Insert a new cell below with the lower portion.
+  local new_cell = {
+    id = require("ipynb.core.notebook").gen_cell_id
+        and require("ipynb.core.notebook").gen_cell_id()
+      or utils.uid(),
+    cell_type = c.cell_type,
+    source = table.concat(lower_lines, "\n"),
+    outputs = c.cell_type == "code" and {} or nil,
+    metadata = {},
+    execution_count = nil,
+  }
+  table.insert(notebook.cells, idx + 1, new_cell)
+
+  M.render(bufnr, notebook, { preserve_undo = true })
+
+  -- Place cursor at the start of the new lower cell.
+  local captured = idx + 1
+  vim.schedule(function()
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+    local new_cs = state.cells[captured]
+    if new_cs then
+      local ns, _ = cell_line_range(bufnr, new_cs)
+      vim.api.nvim_win_set_cursor(0, { ns + 1, 0 })
+    end
+  end)
+end
+
+--- Merge the cell at `idx` with the cell at `idx+1`.
+--- The merged cell keeps the cell_type of the upper cell.
+---@param bufnr integer
+---@param idx integer
+function M.merge_cell_below(bufnr, idx)
+  local state = get_state(bufnr)
+  local notebook = state.notebook
+  if not notebook then
+    return
+  end
+
+  if idx >= #notebook.cells then
+    utils.warn("No cell below to merge with.")
+    return
+  end
+
+  local upper = notebook.cells[idx]
+  local lower = notebook.cells[idx + 1]
+
+  -- Concatenate sources with a newline separator.
+  local upper_src = upper.source or ""
+  local lower_src = lower.source or ""
+  if upper_src ~= "" and lower_src ~= "" then
+    upper.source = upper_src .. "\n" .. lower_src
+  else
+    upper.source = upper_src .. lower_src
+  end
+
+  -- Clear outputs and execution count since the merged cell is a new unit.
+  upper.outputs = upper.cell_type == "code" and {} or nil
+  upper.execution_count = nil
+
+  -- Remove the lower cell from the notebook model.
+  table.remove(notebook.cells, idx + 1)
+
+  M.render(bufnr, notebook, { preserve_undo = true })
+
+  -- Place cursor at the original cell position.
+  local captured = idx
+  vim.schedule(function()
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+    local cs = state.cells[captured]
+    if cs then
+      local ns, _ = cell_line_range(bufnr, cs)
+      vim.api.nvim_win_set_cursor(0, { ns + 1, 0 })
+    end
+  end)
+end
+
 -- ── Output rendering ──────────────────────────────────────────────────────────
 
 --- Append a virt_lines output block below the cell.

--- a/lua/ipynb/ui/commands.lua
+++ b/lua/ipynb/ui/commands.lua
@@ -193,6 +193,24 @@ function M.setup()
     end
   end, { desc = "Toggle current cell type between code and markdown" })
 
+  vim.api.nvim_create_user_command("IpynbCellSplit", function()
+    local cell_mod = require("ipynb.core.cell")
+    local bufnr = vim.api.nvim_get_current_buf()
+    local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if idx then
+      cell_mod.split_cell(bufnr, idx)
+    end
+  end, { desc = "Split the current cell at the cursor line" })
+
+  vim.api.nvim_create_user_command("IpynbCellMerge", function()
+    local cell_mod = require("ipynb.core.cell")
+    local bufnr = vim.api.nvim_get_current_buf()
+    local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if idx then
+      cell_mod.merge_cell_below(bufnr, idx)
+    end
+  end, { desc = "Merge the current cell with the cell below" })
+
   -- ── Output commands ───────────────────────────────────────────────────
 
   vim.api.nvim_create_user_command("IpynbClearOutput", function()

--- a/lua/ipynb/ui/keymaps.lua
+++ b/lua/ipynb/ui/keymaps.lua
@@ -170,6 +170,22 @@ function M.attach(bufnr)
     end
   end, "Jupyter: toggle cell type code/markdown")
 
+  map("n", km.split_cell, function()
+    local cell_mod = require("ipynb.core.cell")
+    local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if idx then
+      cell_mod.split_cell(bufnr, idx)
+    end
+  end, "Jupyter: split cell at cursor")
+
+  map("n", km.merge_cell, function()
+    local cell_mod = require("ipynb.core.cell")
+    local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if idx then
+      cell_mod.merge_cell_below(bufnr, idx)
+    end
+  end, "Jupyter: merge cell with cell below")
+
   -- ── Save ───────────────────────────────────────────────────────────────
   -- Override :w so it saves back to .ipynb format.
   map("n", "<leader>w", function()
@@ -215,6 +231,8 @@ function M.show_help()
     "  " .. km.yank_cell .. "  → yank cell",
     "  " .. km.paste_cell .. "  → paste cell below",
     "  " .. km.toggle_cell_type .. "  → toggle code/markdown",
+    "  " .. km.split_cell .. "  → split cell at cursor",
+    "  " .. km.merge_cell .. "  → merge cell with below",
     "  " .. km.move_cell_up .. "  → move cell up",
     "  " .. km.move_cell_down .. "  → move cell down",
     "  " .. km.add_markdown_below .. "  → add markdown cell below",


### PR DESCRIPTION
## Summary

- Add `split_cell(bufnr, idx)` - splits the current cell at the cursor line into two cells of the same type, clearing outputs on both
- Add `merge_cell_below(bufnr, idx)` - merges the current cell with the cell below, concatenating sources and clearing outputs
- New keymaps: `<leader>cs` (split) and `<leader>cm` (merge), configurable via `keymaps.split_cell` / `keymaps.merge_cell`
- New commands: `:IpynbCellSplit` and `:IpynbCellMerge`
- README updated with all previously undocumented cell editing commands and keymaps

Closes #133
Closes #131

## Test plan

- [ ] Open a multi-line code cell, place cursor in the middle, press `<leader>cs` - cell splits at cursor line
- [ ] Verify both halves retain the original cell type (code or markdown)
- [ ] Place cursor on a cell with a cell below, press `<leader>cm` - cells merge
- [ ] Verify merge concatenates sources with a newline separator
- [ ] Verify split/merge clear outputs and execution counts
- [ ] Verify `:IpynbCellSplit` and `:IpynbCellMerge` commands work
- [ ] Verify help overlay (`<leader>jh`) shows split and merge entries