### PR TITLE
fix: clamp floating window dimensions to terminal size

### DIFF
--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -688,12 +688,12 @@ function M.show_info(bufnr)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   vim.api.nvim_buf_set_option(buf, "modifiable", false)
 
-  local width = 38
-  local height = #lines
+  local width = math.min(38, vim.o.columns - 4)
+  local height = math.min(#lines, vim.o.lines - 4)
   local win = vim.api.nvim_open_win(buf, true, {
     relative = "editor",
-    row = math.floor((vim.o.lines - height) / 2),
-    col = math.floor((vim.o.columns - width) / 2),
+    row = math.max(0, math.floor((vim.o.lines - height) / 2)),
+    col = math.max(0, math.floor((vim.o.columns - width) / 2)),
     width = width,
     height = height,
     style = "minimal",

--- a/lua/ipynb/ui/keymaps.lua
+++ b/lua/ipynb/ui/keymaps.lua
@@ -251,10 +251,10 @@ function M.show_help()
   vim.api.nvim_buf_set_option(buf, "modifiable", false)
   vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
 
-  local width = 44
-  local height = #lines
-  local row = math.floor((vim.o.lines - height) / 2)
-  local col = math.floor((vim.o.columns - width) / 2)
+  local width = math.min(44, vim.o.columns - 4)
+  local height = math.min(#lines, vim.o.lines - 4)
+  local row = math.max(0, math.floor((vim.o.lines - height) / 2))
+  local col = math.max(0, math.floor((vim.o.columns - width) / 2))
 
   local win = vim.api.nvim_open_win(buf, true, {
     relative = "editor",


### PR DESCRIPTION
## Summary

- Clamp help overlay (`show_help()`) width, height, row, and col to prevent negative values when terminal is smaller than the window content
- Apply same fix to kernel info window (`show_info()`) in kernel/init.lua
- Both windows now gracefully fit within any terminal size instead of crashing with `Invalid floating window config`

Closes #154

## Test plan

- [ ] Resize terminal to ~20 rows, press `<leader>jh` - help overlay opens without error
- [ ] Resize terminal to ~15 columns, press `<leader>jh` - window fits within terminal
- [ ] Run `:IpynbKernelInfo` in a small terminal - no crash
- [ ] Normal-sized terminal still centers windows correctly