### PR TITLE
fix: allow adding first cell to empty notebooks

### DIFF
--- a/lua/ipynb/ui/commands.lua
+++ b/lua/ipynb/ui/commands.lua
@@ -128,6 +128,12 @@ function M.setup()
     local cell_mod = require("ipynb.core.cell")
     local bufnr = vim.api.nvim_get_current_buf()
     local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if not idx then
+      local nb = cell_mod.get_notebook(bufnr)
+      if nb and #nb.cells == 0 then
+        idx = 0
+      end
+    end
     if idx then
       cell_mod.add_cell_below(bufnr, idx)
     end
@@ -146,6 +152,12 @@ function M.setup()
     local cell_mod = require("ipynb.core.cell")
     local bufnr = vim.api.nvim_get_current_buf()
     local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if not idx then
+      local nb = cell_mod.get_notebook(bufnr)
+      if nb and #nb.cells == 0 then
+        idx = 0
+      end
+    end
     if idx then
       cell_mod.add_cell_below(bufnr, idx, "markdown")
     end
@@ -155,6 +167,12 @@ function M.setup()
     local cell_mod = require("ipynb.core.cell")
     local bufnr = vim.api.nvim_get_current_buf()
     local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if not idx then
+      local nb = cell_mod.get_notebook(bufnr)
+      if nb and #nb.cells == 0 then
+        idx = 1
+      end
+    end
     if idx then
       cell_mod.add_cell_above(bufnr, idx, "markdown")
     end

--- a/lua/ipynb/ui/keymaps.lua
+++ b/lua/ipynb/ui/keymaps.lua
@@ -77,6 +77,12 @@ function M.attach(bufnr)
   map("n", km.add_cell_below, function()
     local cell_mod = require("ipynb.core.cell")
     local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if not idx then
+      local nb = cell_mod.get_notebook(bufnr)
+      if nb and #nb.cells == 0 then
+        idx = 0
+      end
+    end
     if idx then
       cell_mod.add_cell_below(bufnr, idx)
     end
@@ -85,6 +91,12 @@ function M.attach(bufnr)
   map("n", km.add_cell_above, function()
     local cell_mod = require("ipynb.core.cell")
     local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if not idx then
+      local nb = cell_mod.get_notebook(bufnr)
+      if nb and #nb.cells == 0 then
+        idx = 1
+      end
+    end
     if idx then
       cell_mod.add_cell_above(bufnr, idx)
     end
@@ -109,6 +121,12 @@ function M.attach(bufnr)
   map("n", km.add_markdown_below, function()
     local cell_mod = require("ipynb.core.cell")
     local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if not idx then
+      local nb = cell_mod.get_notebook(bufnr)
+      if nb and #nb.cells == 0 then
+        idx = 0
+      end
+    end
     if idx then
       cell_mod.add_cell_below(bufnr, idx, "markdown")
     end
@@ -117,6 +135,12 @@ function M.attach(bufnr)
   map("n", km.add_markdown_above, function()
     local cell_mod = require("ipynb.core.cell")
     local _, idx = cell_mod.cell_at_cursor(bufnr)
+    if not idx then
+      local nb = cell_mod.get_notebook(bufnr)
+      if nb and #nb.cells == 0 then
+        idx = 1
+      end
+    end
     if idx then
       cell_mod.add_cell_above(bufnr, idx, "markdown")
     end


### PR DESCRIPTION
## Summary

- When a notebook has 0 cells, `cell_at_cursor()` returns nil and all add-cell keymaps/commands silently do nothing
- Add fallback logic in keymaps (`<leader>co`, `<leader>cO`, `<leader>mo`, `<leader>mO`) and commands (`:IpynbCellAdd`, `:IpynbCellAddMarkdown`, `:IpynbCellAddMarkdownAbove`) to detect empty notebooks and pass `idx = 0` to `add_cell_below` or `idx = 1` to `add_cell_above`
- Users can now create the first cell in a freshly created or emptied notebook

Closes #153

## Test plan

- [ ] Create a minimal empty notebook: `{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}`
- [ ] Open it and press `<leader>co` - first code cell appears
- [ ] Delete the cell, press `<leader>mo` - first markdown cell appears
- [ ] Verify `:IpynbCellAdd` also works on empty notebook
- [ ] Verify normal non-empty notebooks are unaffected