### PR TITLE
fix(lua): set conceallevel=2 for markdown cell conceals

### DIFF
--- a/lua/ipynb/core/notebook_buf.lua
+++ b/lua/ipynb/core/notebook_buf.lua
@@ -45,9 +45,14 @@ local function setup_buf_options(bufnr)
   vim.b[bufnr].conform_format_on_insert_leave = false
   vim.bo[bufnr].formatexpr = ""
 
-  -- Conceal decorations look better without full conceallevel in insert mode.
-  vim.api.nvim_win_set_option(0, "conceallevel", 0)
-  vim.api.nvim_win_set_option(0, "signcolumn", "yes")
+  -- conceallevel=2 lets markdown.lua conceal heading markers, blockquote
+  -- prefixes, and link delimiters.  Target the actual notebook window, not
+  -- window 0 which may be a different split.
+  local win = vim.fn.bufwinid(bufnr)
+  if win ~= -1 then
+    vim.api.nvim_win_set_option(win, "conceallevel", 2)
+    vim.api.nvim_win_set_option(win, "signcolumn", "yes")
+  end
 end
 
 --- Set a human-readable buffer name (shows in tabline / statusline).


### PR DESCRIPTION
## Summary

- Change `conceallevel` from `0` to `2` so markdown.lua conceal extmarks (heading markers, blockquote prefixes, link delimiters) actually render
- Use `vim.fn.bufwinid(bufnr)` instead of window `0` to target the correct notebook window in multi-split layouts
- Guard with `win ~= -1` check in case the buffer has no visible window

Closes #157

## Test plan

- [ ] Open a notebook with markdown cells - verify heading `#` markers are concealed
- [ ] Verify blockquote `>` markers are concealed
- [ ] Verify link delimiters are concealed
- [ ] Open notebook in a split - verify the other split's conceallevel is not affected