### PR TITLE
fix(lua): remove WinResized handler that wiped undo tree

### DIFF
--- a/lua/ipynb/init.lua
+++ b/lua/ipynb/init.lua
@@ -74,22 +74,6 @@ function M._register_autocmds()
     end,
     desc = "ipynb: save .ipynb notebook",
   })
-
-  -- WinResized: re-render borders when the window width changes (border
-  -- decorations are width-aware).
-  vim.api.nvim_create_autocmd("WinResized", {
-    group = group,
-    callback = function()
-      local bufnr = vim.api.nvim_get_current_buf()
-      if require("ipynb.core.notebook_buf").is_managed(bufnr) then
-        local nb = require("ipynb.core.cell").get_notebook(bufnr)
-        if nb then
-          require("ipynb.core.cell").render(bufnr, nb)
-        end
-      end
-    end,
-    desc = "ipynb: re-render on window resize",
-  })
 end
 
 -- ── Convenience public API ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Remove the global `WinResized` autocmd from `init.lua` that called `render()` without `preserve_undo`, which set `undolevels=-1` and cleared the entire undo tree on every window resize event
- This handler was redundant with the per-buffer `VimResized` + `WinEnter` handlers in `notebook_buf.lua` that already handle width-change re-rendering correctly (with width tracking and `preserve_undo=true`)
- Undo now works normally for in-cell text editing after window resize events

Closes #177

## Test plan

- [ ] Open a notebook, type text in a cell, press `u` - text should undo
- [ ] Resize the terminal window, then press `u` - undo should still work
- [ ] Open a vertical split, edit text, close the split, press `u` - undo should still work
- [ ] Resize terminal with a notebook open - cell borders should still re-render correctly (handled by `notebook_buf.lua` handlers)