### PR TITLE
fix(lua): preserve existing cmp sources when adding ipynb source

### DIFF
--- a/lua/ipynb/kernel/completion.lua
+++ b/lua/ipynb/kernel/completion.lua
@@ -177,14 +177,16 @@ function M.attach(bufnr)
     M._cmp_registered = true
   end
 
-  -- Add source to this buffer's cmp config.
-  cmp.setup.buffer({
-    sources = cmp.config.sources({
-      { name = "ipynb", priority = 1000 },
-    }, {
-      { name = "buffer" },
-    }),
-  })
+  -- Prepend ipynb source to the existing buffer/global sources so LSP,
+  -- snippets, path, etc. are preserved rather than replaced.
+  local existing = cmp.get_config().sources or {}
+  local merged = { { name = "ipynb", priority = 1000 } }
+  for _, s in ipairs(existing) do
+    if s.name ~= "ipynb" then
+      merged[#merged + 1] = s
+    end
+  end
+  cmp.setup.buffer({ sources = merged })
 end
 
 M._cmp_registered = false


### PR DESCRIPTION
## Summary

- Prepend the ipynb kernel completion source to the user's existing nvim-cmp sources instead of replacing them
- Previously `cmp.setup.buffer()` was called with only `ipynb` + `buffer`, discarding globally configured sources like `nvim_lsp`, `luasnip`, and `path`
- Deduplicates by skipping any existing `ipynb` entry before merging

Closes #155

## Test plan

- [ ] Configure nvim-cmp globally with sources: `nvim_lsp`, `luasnip`, `path`, `buffer`
- [ ] Open a notebook and start kernel
- [ ] Trigger completion in insert mode - verify LSP, snippet, path, and kernel completions all appear
- [ ] Verify ipynb kernel completions have highest priority (appear first)