### PR TITLE
fix(lua): clean up image temp files and output state on BufDelete

### DIFF
--- a/lua/ipynb/core/notebook_buf.lua
+++ b/lua/ipynb/core/notebook_buf.lua
@@ -201,6 +201,15 @@ function M.open(path, bufnr)
     buffer = bufnr,
     once = true,
     callback = function()
+      -- Clean up output state, image placements, and temp files BEFORE
+      -- cell.on_buf_delete wipes buf_state (which holds the cell list).
+      local cells = cell.get_cells(bufnr)
+      if cells and #cells > 0 then
+        local ok_out, output_mod = pcall(require, "ipynb.kernel.output")
+        if ok_out then
+          output_mod.clear_all(bufnr, cells)
+        end
+      end
       cell.on_buf_delete(bufnr)
       -- Stop kernel bridge if one is running for this buffer.
       local ok, kernel = pcall(require, "ipynb.kernel")


### PR DESCRIPTION
## Summary

- Call `output.clear_all(bufnr, cells)` in the `BufDelete` handler before `cell.on_buf_delete()` wipes the cell state
- This closes snacks.nvim image placements and removes temp files (PNG/JPEG/SVG) written during output rendering
- Previously these temp files accumulated in the temp directory across long sessions with many notebooks opened and closed

Closes #161

## Test plan

- [ ] Open a notebook with image output, close the buffer, verify temp files are removed
- [ ] Open and close multiple notebooks in a session, check `/tmp` for lingering image files
- [ ] Verify normal buffer close still works (no errors from cleanup)