### PR TITLE
fix(lua): derive buffer filetype from notebook kernel language

### DIFF
--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -340,8 +340,9 @@ function M.render(bufnr, notebook, opts)
     end
   end
 
-  -- Lock filetype for syntax highlighting.
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "python")
+  -- Set filetype from notebook kernel language for correct treesitter / LSP.
+  local ft = require("ipynb.core.notebook").notebook_language(notebook)
+  vim.api.nvim_buf_set_option(bufnr, "filetype", ft)
 
   -- Restore undo tracking (only when we suppressed it above).
   if not preserve_undo then

--- a/lua/ipynb/core/notebook.lua
+++ b/lua/ipynb/core/notebook.lua
@@ -185,6 +185,22 @@ function M.kernel_name(notebook)
   return "python3"
 end
 
+--- Code language for the notebook (from kernelspec / language_info metadata).
+--- Used to set the buffer filetype so treesitter and LSP match the kernel.
+---@param notebook table
+---@return string
+function M.notebook_language(notebook)
+  local ks = (notebook.metadata or {}).kernelspec
+  if ks and ks.language then
+    return ks.language
+  end
+  local li = (notebook.metadata or {}).language_info
+  if li and li.name then
+    return li.name
+  end
+  return "python"
+end
+
 --- Language name for a cell (looks at notebook kernelspec metadata).
 ---@param notebook table
 ---@param cell table

--- a/lua/ipynb/core/notebook_buf.lua
+++ b/lua/ipynb/core/notebook_buf.lua
@@ -35,9 +35,6 @@ local function setup_buf_options(bufnr)
   vim.api.nvim_buf_set_option(bufnr, "readonly", false)
   vim.api.nvim_buf_set_option(bufnr, "swapfile", false)
 
-  -- Python filetype for treesitter / LSP.
-  vim.api.nvim_buf_set_option(bufnr, "filetype", "python")
-
   -- Disable formatters. The buffer holds raw cell source from multiple cells;
   -- running ruff/black/conform over it would corrupt multi-cell content and
   -- trigger spurious re-renders.
@@ -89,13 +86,13 @@ local function attach_lsp(bufnr)
   end
 
   -- Strategy 1: re-fire FileType so lspconfig autostart logic runs.
-  -- pattern="python" is used instead of buf=bufnr (buf= requires Neovim 0.10+).
-  -- The double vim.schedule at the call site ensures this fires two ticks after
-  -- BufReadCmd, by which point all single-tick deferrals (kernel.start, etc.)
-  -- have settled and the notebook buffer is reliably the current buffer.
-  vim.api.nvim_exec_autocmds("FileType", { pattern = "python" })
+  -- The buffer filetype is set by cell.render() from notebook metadata before
+  -- this function is called.  pattern= must match the actual filetype so the
+  -- correct LSP server attaches (e.g. r_language_server for R notebooks).
+  local buf_ft = vim.api.nvim_buf_get_option(bufnr, "filetype")
+  vim.api.nvim_exec_autocmds("FileType", { pattern = buf_ft })
 
-  -- Strategy 2: attach any already-running Python LSP client.
+  -- Strategy 2: attach any already-running LSP client that serves this filetype.
   local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
   for _, client in ipairs(get_clients()) do
     if vim.lsp.buf_is_attached(bufnr, client.id) then
@@ -103,7 +100,7 @@ local function attach_lsp(bufnr)
     end
     local fts = (client.config or {}).filetypes or {}
     for _, ft in ipairs(fts) do
-      if ft == "python" then
+      if ft == buf_ft then
         pcall(vim.lsp.buf_attach_client, bufnr, client.id)
         break
       end
@@ -328,8 +325,9 @@ function M.open(path, bufnr)
 
   -- Filter LSP diagnostics that fall inside markdown cell ranges.
   --
-  -- The buffer filetype is python so pyright/pylsp attach and publish
-  -- diagnostics for the whole buffer.  Markdown prose (English sentences,
+  -- The buffer filetype matches the notebook kernel language, so the
+  -- attached LSP publishes diagnostics for the whole buffer.  Markdown
+  -- prose (English sentences,
   -- bullet points, etc.) is not Python code and produces false "undefined
   -- name" / syntax errors.  After every diagnostic publish cycle, walk each
   -- LSP client's namespace and drop diagnostics whose line falls inside a


### PR DESCRIPTION
## Summary

- Add `notebook_language(notebook)` helper to `notebook.lua` that reads `kernelspec.language` or `language_info.name` from metadata, falling back to `"python"`
- Replace hardcoded `filetype = "python"` in `cell.render()` with dynamic filetype from notebook metadata
- Remove premature filetype set from `setup_buf_options()` (redundant with render)
- Update `attach_lsp()` to read the buffer's actual filetype instead of hardcoding `"python"`, so the correct LSP server attaches for non-Python notebooks

This fixes syntax highlighting, treesitter parsing, and LSP attachment for R, Julia, JavaScript, and other non-Python kernel notebooks.

Closes #152

## Test plan

- [ ] Open a Python notebook - verify Python syntax highlighting and pyright/pylsp attach
- [ ] Open an R notebook (if available) - verify R syntax highlighting
- [ ] Open a notebook with no kernel metadata - verify falls back to Python
- [ ] Verify LSP diagnostics still filter correctly for markdown cells