### PR TITLE
docs: update README and CLAUDE.md to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ ipynb/
 │   ├── init.lua              # Entry point: setup(), BufReadCmd/BufWriteCmd autocmds
 │   ├── config.lua            # Typed defaults + user deep-merge (IpynbConfig)
 │   ├── utils.lua             # log/warn/err, read_file/write_file, uid, has_plugin
+│   ├── health.lua            # :checkhealth ipynb provider
 │   ├── core/
 │   │   ├── notebook.lua      # .ipynb parse / serialise - nbformat 3 & 4
 │   │   ├── notebook_buf.lua  # Buffer lifecycle: open, save, sync, cleanup hooks
@@ -32,12 +33,12 @@ ipynb/
 │   │   ├── output.lua        # Output chunk -> virt_lines renderer + accumulator
 │   │   └── completion.lua    # omnifunc + nvim-cmp async source
 │   └── ui/
+│       ├── ansi.lua          # SGR ANSI escape parser: 16/256/truecolor, bold/italic
 │       ├── image.lua         # snacks.nvim image rendering: PNG/JPEG/SVG via Placement
-│       ├── health.lua        # :checkhealth ipynb provider
 │       ├── markdown.lua      # Markdown cell extmark decorator (concealing)
 │       ├── inspector.lua     # Variable inspector floating window
 │       ├── keymaps.lua       # Buffer-local keymaps + floating help overlay
-│       └── commands.lua      # All :Jupyter* user commands
+│       └── commands.lua      # All :Ipynb* user commands
 ├── python/
 │   ├── pyproject.toml        # uv project, Python >=3.12 - runtime deps
 │   ├── uv.lock               # Reproducible lockfile - always commit alongside toml
@@ -49,6 +50,7 @@ ipynb/
 ├── test/
 │   ├── minimal_init.lua      # Minimal Neovim init for vusted test runner
 │   ├── headless_test.lua     # Headless integration checks (module loading, statics)
+│   ├── test_notebook.ipynb   # Sample notebook fixture for tests
 │   ├── config_spec.lua       # busted spec: ipynb.config
 │   ├── utils_spec.lua        # busted spec: ipynb.utils
 │   ├── notebook_spec.lua     # busted spec: ipynb.core.notebook
@@ -56,6 +58,11 @@ ipynb/
 │   ├── output_spec.lua       # busted spec: ipynb.kernel.output
 │   └── inspector_spec.lua    # busted spec: ipynb.ui.inspector
 ├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug_report.md     # Bug report issue template
+│   │   ├── feature_request.md # Feature request issue template
+│   │   ├── other.md          # General issue template
+│   │   └── config.yml        # Issue template chooser config
 │   └── workflows/
 │       ├── ci.yml            # test + lint + format-check on every push/PR
 │       └── release.yml       # python-semantic-release on push to main
@@ -83,6 +90,7 @@ ipynb/
 | `require("ipynb.kernel")` | `lua/ipynb/kernel/init.lua` |
 | `require("ipynb.kernel.output")` | `lua/ipynb/kernel/output.lua` |
 | `require("ipynb.kernel.completion")` | `lua/ipynb/kernel/completion.lua` |
+| `require("ipynb.ui.ansi")` | `lua/ipynb/ui/ansi.lua` |
 | `require("ipynb.ui.image")` | `lua/ipynb/ui/image.lua` |
 | `require("ipynb.ui.markdown")` | `lua/ipynb/ui/markdown.lua` |
 | `require("ipynb.ui.inspector")` | `lua/ipynb/ui/inspector.lua` |

--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ Press `<leader>jh` to show the help overlay at any time.
 | `<leader>mo` | Add markdown cell below |
 | `<leader>mO` | Add markdown cell above |
 | `<leader>cd` | Delete current cell |
+| `<leader>ck` | Move current cell up |
+| `<leader>cj` | Move current cell down |
+| `<leader>cc` | Duplicate current cell |
+| `<leader>cy` | Yank cell into cell register |
+| `<leader>cv` | Paste yanked cell below |
+| `<leader>ct` | Toggle cell type (code/markdown) |
+| `<leader>cs` | Split cell at cursor line |
+| `<leader>cm` | Merge cell with the cell below |
 | `<leader>cx` | Clear current cell output |
 | `<leader>cX` | Clear all cell outputs |
 | `<leader>w` | Save notebook |
@@ -212,10 +220,12 @@ Press `<leader>jh` to show the help overlay at any time.
 | `:IpynbKernelRestart` | Restart kernel and clear all output |
 | `:IpynbKernelInterrupt` | Send interrupt (Ctrl-C) |
 | `:IpynbKernelInfo` | Show kernel status window |
+| `:IpynbKernelAttach [file]` | Attach to an existing kernel via connection file |
 | `:IpynbRun` | Run current cell |
 | `:IpynbRunAdvance` | Run cell and advance to next |
 | `:IpynbRunAll` | Run all cells |
 | `:IpynbRunAbove` | Run all cells above cursor |
+| `:IpynbRunBelow` | Run all cells from cursor downwards |
 | `:IpynbCellAdd` | Add code cell below |
 | `:IpynbCellDelete` | Delete current cell |
 | `:IpynbCellAddMarkdown` | Add markdown cell below |
@@ -241,9 +251,10 @@ or `setup()` to override.
 ```lua
 require("ipynb").setup({
   kernel = {
-    default_kernel = "python3",
-    auto_start     = true,       -- start kernel automatically on first run
-    python_path    = "python3",  -- fallback if uv venv is not found
+    default_kernel   = "python3",
+    auto_start       = true,       -- start kernel automatically on first run
+    python_path      = "python3",  -- fallback if uv venv is not found
+    restart_on_crash = false,      -- auto-restart kernel after unexpected crash
   },
   ui = {
     show_execution_count = true,


### PR DESCRIPTION
## Summary

- Add 7 missing keymaps to README summary table: move up/down, duplicate, yank, paste, toggle type, split, merge
- Add `:IpynbKernelAttach` and `:IpynbRunBelow` to README commands table
- Add `restart_on_crash` config option to README configuration block
- Fix `health.lua` path in CLAUDE.md file tree (was listed under `ui/`, actually at root level)
- Add `ui/ansi.lua` to CLAUDE.md file tree and module paths table (was completely missing)
- Add `test/test_notebook.ipynb` and `.github/ISSUE_TEMPLATE/` to CLAUDE.md layout
- Fix `:Jupyter*` to `:Ipynb*` in CLAUDE.md comment

## Test plan

- [ ] Verify all keymaps listed in README match `lua/ipynb/ui/keymaps.lua`
- [ ] Verify all commands listed in README match `lua/ipynb/ui/commands.lua`
- [ ] Verify CLAUDE.md file tree matches actual `ls` output
- [ ] Verify module paths table matches actual `require()` paths