### PR TITLE
fix: migrate deprecated APIs, consolidate cell IDs, and harden kernel

### DIFF
--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -243,8 +243,8 @@ function M.render(bufnr, notebook, opts)
   state.cells = {}
 
   -- Unlock the buffer for writing.
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
-  vim.api.nvim_buf_set_option(bufnr, "readonly", false)
+  vim.bo[bufnr].modifiable = true
+  vim.bo[bufnr].readonly = false
 
   -- Optionally make all nvim_buf_set_lines calls undo-invisible.
   --
@@ -260,8 +260,8 @@ function M.render(bufnr, notebook, opts)
   local preserve_undo = opts and opts.preserve_undo or false
   local saved_ul
   if not preserve_undo then
-    saved_ul = vim.api.nvim_buf_get_option(bufnr, "undolevels")
-    vim.api.nvim_buf_set_option(bufnr, "undolevels", -1)
+    saved_ul = vim.bo[bufnr].undolevels
+    vim.bo[bufnr].undolevels = -1
   end
 
   -- Clear everything.
@@ -342,11 +342,11 @@ function M.render(bufnr, notebook, opts)
 
   -- Set filetype from notebook kernel language for correct treesitter / LSP.
   local ft = require("ipynb.core.notebook").notebook_language(notebook)
-  vim.api.nvim_buf_set_option(bufnr, "filetype", ft)
+  vim.bo[bufnr].filetype = ft
 
   -- Restore undo tracking (only when we suppressed it above).
   if not preserve_undo then
-    vim.api.nvim_buf_set_option(bufnr, "undolevels", saved_ul)
+    vim.bo[bufnr].undolevels = saved_ul
   end
 
   -- Notify render hooks (e.g. kernel remap of pending cell_state refs).
@@ -510,14 +510,12 @@ function M.add_cell_below(bufnr, idx, cell_type)
   cell_type = cell_type or "code"
   -- Insert a new empty cell into the notebook model.
   local new_cell = {
-    id = require("ipynb.core.notebook").gen_cell_id
-        and require("ipynb.core.notebook").gen_cell_id()
-      or utils.uid(),
+    id = require("ipynb.core.notebook").gen_cell_id(),
     cell_type = cell_type,
     source = "",
     outputs = cell_type == "code" and {} or nil,
     metadata = {},
-    execution_count = cell_type == "code" and nil or nil,
+    execution_count = nil,
   }
   table.insert(notebook.cells, idx + 1, new_cell)
 
@@ -556,7 +554,7 @@ function M.add_cell_above(bufnr, idx, cell_type)
 
   cell_type = cell_type or "code"
   local new_cell = {
-    id = utils.uid(),
+    id = require("ipynb.core.notebook").gen_cell_id(),
     cell_type = cell_type,
     source = "",
     outputs = cell_type == "code" and {} or nil,
@@ -663,7 +661,7 @@ function M.duplicate_cell(bufnr, idx)
   end
 
   local copy = vim.deepcopy(notebook.cells[idx])
-  copy.id = utils.uid()
+  copy.id = require("ipynb.core.notebook").gen_cell_id()
   copy.execution_count = nil
   if copy.outputs then
     copy.outputs = {}
@@ -721,7 +719,7 @@ function M.paste_cell(bufnr, idx)
   end
 
   local pasted = vim.deepcopy(_yank_register)
-  pasted.id = utils.uid()
+  pasted.id = require("ipynb.core.notebook").gen_cell_id()
   pasted.execution_count = nil
   if pasted.outputs then
     pasted.outputs = {}
@@ -821,9 +819,7 @@ function M.split_cell(bufnr, idx)
 
   -- Insert a new cell below with the lower portion.
   local new_cell = {
-    id = require("ipynb.core.notebook").gen_cell_id
-        and require("ipynb.core.notebook").gen_cell_id()
-      or utils.uid(),
+    id = require("ipynb.core.notebook").gen_cell_id(),
     cell_type = c.cell_type,
     source = table.concat(lower_lines, "\n"),
     outputs = c.cell_type == "code" and {} or nil,

--- a/lua/ipynb/core/notebook.lua
+++ b/lua/ipynb/core/notebook.lua
@@ -83,6 +83,7 @@ function M.parse(raw, path)
   local notebook = {
     path = path,
     nbformat = nbformat,
+    nbformat_minor = raw.nbformat_minor or 5,
     metadata = raw.metadata or {},
     cells = cells,
   }
@@ -138,8 +139,8 @@ function M.save(notebook)
   end
 
   local raw = {
-    nbformat = 4,
-    nbformat_minor = 5,
+    nbformat = notebook.nbformat or 4,
+    nbformat_minor = notebook.nbformat_minor or 5,
     metadata = notebook.metadata or {},
     cells = raw_cells,
   }
@@ -225,5 +226,7 @@ function M.cell_language(notebook, cell)
 
   return "python"
 end
+
+M.gen_cell_id = gen_cell_id
 
 return M

--- a/lua/ipynb/core/notebook_buf.lua
+++ b/lua/ipynb/core/notebook_buf.lua
@@ -26,14 +26,21 @@ local managed_paths = {}
 
 -- ── Buffer setup ──────────────────────────────────────────────────────────────
 
+--- Apply window-level options to whatever window is displaying this buffer.
+---@param winid integer
+local function setup_win_options(winid)
+  vim.wo[winid].conceallevel = 2
+  vim.wo[winid].signcolumn = "yes"
+end
+
 --- Configure buffer-level options for a notebook buffer.
 ---@param bufnr integer
 local function setup_buf_options(bufnr)
   -- Treat as a normal editable buffer.
-  vim.api.nvim_buf_set_option(bufnr, "buftype", "")
-  vim.api.nvim_buf_set_option(bufnr, "modifiable", true)
-  vim.api.nvim_buf_set_option(bufnr, "readonly", false)
-  vim.api.nvim_buf_set_option(bufnr, "swapfile", false)
+  vim.bo[bufnr].buftype = ""
+  vim.bo[bufnr].modifiable = true
+  vim.bo[bufnr].readonly = false
+  vim.bo[bufnr].swapfile = false
 
   -- Disable formatters. The buffer holds raw cell source from multiple cells;
   -- running ruff/black/conform over it would corrupt multi-cell content and
@@ -47,8 +54,7 @@ local function setup_buf_options(bufnr)
   -- window 0 which may be a different split.
   local win = vim.fn.bufwinid(bufnr)
   if win ~= -1 then
-    vim.api.nvim_win_set_option(win, "conceallevel", 2)
-    vim.api.nvim_win_set_option(win, "signcolumn", "yes")
+    setup_win_options(win)
   end
 end
 
@@ -89,7 +95,7 @@ local function attach_lsp(bufnr)
   -- The buffer filetype is set by cell.render() from notebook metadata before
   -- this function is called.  pattern= must match the actual filetype so the
   -- correct LSP server attaches (e.g. r_language_server for R notebooks).
-  local buf_ft = vim.api.nvim_buf_get_option(bufnr, "filetype")
+  local buf_ft = vim.bo[bufnr].filetype
   vim.api.nvim_exec_autocmds("FileType", { pattern = buf_ft })
 
   -- Strategy 2: attach any already-running LSP client that serves this filetype.
@@ -216,6 +222,18 @@ function M.open(path, bufnr)
       -- Remove from both tracking tables so the path can be reopened.
       managed_paths[norm_path] = nil
       managed[bufnr] = nil
+    end,
+  })
+
+  -- Apply window options when the buffer first appears in a window (handles
+  -- background-loaded buffers from session restore, :badd, etc.).
+  vim.api.nvim_create_autocmd("BufWinEnter", {
+    buffer = bufnr,
+    callback = function()
+      local win = vim.fn.bufwinid(bufnr)
+      if win ~= -1 then
+        setup_win_options(win)
+      end
     end,
   })
 
@@ -404,7 +422,7 @@ function M.open(path, bufnr)
   })
 
   -- Mark buffer as not modified after initial load.
-  vim.api.nvim_buf_set_option(bufnr, "modified", false)
+  vim.bo[bufnr].modified = false
 
   -- Move cursor to line 1. BufReadCmd can trigger a shada position restore
   -- via BufEnter autocmds after this handler returns, so defer until the
@@ -439,7 +457,7 @@ function M.save(bufnr)
 
   local ok, err = notebook.save(nb)
   if ok then
-    vim.api.nvim_buf_set_option(bufnr, "modified", false)
+    vim.bo[bufnr].modified = false
     utils.info("Notebook saved: " .. vim.fn.fnamemodify(nb.path, ":t"))
   else
     utils.err("Save failed: " .. (err or "unknown error"))

--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -195,7 +195,7 @@ local function dispatch(bufnr, msg)
         if state == "busy" then
           cell.update_status(bufnr, pending.cell_state, "busy", nil)
         elseif state == "idle" then
-          local elapsed_ms = vim.loop.now() - pending.start_ms
+          local elapsed_ms = vim.uv.now() - pending.start_ms
           cell.update_status(bufnr, pending.cell_state, "idle", elapsed_ms)
           s.pending[id] = nil
           -- Auto-save after execution if configured.
@@ -256,7 +256,7 @@ local function dispatch(bufnr, msg)
             end
           end
           -- Mark buffer modified so Neovim warns on :q with unsaved outputs.
-          pcall(vim.api.nvim_buf_set_option, bufnr, "modified", true)
+          pcall(function() vim.bo[bufnr].modified = true end)
         end
         if t == "error" then
           cell.update_status(bufnr, pending.cell_state, "error", nil)
@@ -384,7 +384,7 @@ local function spawn_bridge(bufnr)
           local kn_saved = st.kernel_name
           if config.get().kernel.restart_on_crash then
             -- Track crash timestamps and prune those outside the window.
-            local now = vim.loop.now() / 1000
+            local now = vim.uv.now() / 1000
             local recent = {}
             for _, t in ipairs(st._crash_times or {}) do
               if now - t < CRASH_WINDOW_SECS then
@@ -531,6 +531,10 @@ function M.attach(bufnr, connection_file)
   if connection_file then
     cmd.connection_file = connection_file
   end
+  local cfg = config.get()
+  if cfg.kernel.connection_dir then
+    cmd.connection_dir = cfg.kernel.connection_dir
+  end
   send(bufnr, cmd)
 end
 
@@ -560,9 +564,16 @@ function M.run_current_cell(bufnr)
     if cfg.kernel.auto_start then
       M.start(bufnr, nil)
       -- Poll every 500 ms until the kernel signals idle, then run.
+      local retries = 0
+      local max_retries = 60
       local function _await_and_run()
         local st = get_state(bufnr)
         if not st.job_id or st.status == "stopped" then
+          return
+        end
+        retries = retries + 1
+        if retries > max_retries then
+          utils.warn("Kernel did not become ready after 30s - aborting cell execution")
           return
         end
         if st.status == "idle" then
@@ -582,7 +593,7 @@ function M.run_current_cell(bufnr)
 
   local mid = next_msg_id(bufnr)
   s.pending[mid] =
-    { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.loop.now() }
+    { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.uv.now() }
 
   cell.update_status(bufnr, cs, "busy", nil)
   local code = cell.get_cell_source(bufnr, cs)
@@ -631,7 +642,7 @@ function M.run_all(bufnr)
       clear_cell_output(bufnr, cs)
       local mid = next_msg_id(bufnr)
       s.pending[mid] =
-        { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.loop.now() }
+        { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.uv.now() }
       cell.update_status(bufnr, cs, "busy", nil)
       send(bufnr, { cmd = "execute", code = cell.get_cell_source(bufnr, cs), msg_id = mid })
     end
@@ -656,7 +667,7 @@ function M.run_all_above(bufnr)
       clear_cell_output(bufnr, cs)
       local mid = next_msg_id(bufnr)
       s.pending[mid] =
-        { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.loop.now() }
+        { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.uv.now() }
       cell.update_status(bufnr, cs, "busy", nil)
       send(bufnr, { cmd = "execute", code = cell.get_cell_source(bufnr, cs), msg_id = mid })
     end
@@ -682,7 +693,7 @@ function M.run_all_below(bufnr)
       clear_cell_output(bufnr, cs)
       local mid = next_msg_id(bufnr)
       s.pending[mid] =
-        { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.loop.now() }
+        { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.uv.now() }
       cell.update_status(bufnr, cs, "busy", nil)
       send(bufnr, { cmd = "execute", code = cell.get_cell_source(bufnr, cs), msg_id = mid })
     end
@@ -738,7 +749,7 @@ function M.show_info(bufnr)
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-  vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  vim.bo[buf].modifiable = false
 
   local width = math.min(38, vim.o.columns - 4)
   local height = math.min(#lines, vim.o.lines - 4)

--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -256,7 +256,9 @@ local function dispatch(bufnr, msg)
             end
           end
           -- Mark buffer modified so Neovim warns on :q with unsaved outputs.
-          pcall(function() vim.bo[bufnr].modified = true end)
+          pcall(function()
+            vim.bo[bufnr].modified = true
+          end)
         end
         if t == "error" then
           cell.update_status(bufnr, pending.cell_state, "error", nil)
@@ -592,8 +594,7 @@ function M.run_current_cell(bufnr)
   clear_cell_output(bufnr, cs)
 
   local mid = next_msg_id(bufnr)
-  s.pending[mid] =
-    { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.uv.now() }
+  s.pending[mid] = { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.uv.now() }
 
   cell.update_status(bufnr, cs, "busy", nil)
   local code = cell.get_cell_source(bufnr, cs)

--- a/python/kernel_bridge.py
+++ b/python/kernel_bridge.py
@@ -428,8 +428,13 @@ def cmd_interrupt(_data: dict) -> None:
             _km.interrupt_kernel()
         except Exception as exc:
             send({"type": "error_internal", "message": f"Interrupt failed: {exc}"})
+    elif _kc is not None:
+        try:
+            _kc.session.send(_kc.control_channel.socket, "interrupt_request")
+        except Exception as exc:
+            send({"type": "error_internal", "message": f"Interrupt (attached) failed: {exc}"})
     else:
-        send({"type": "error_internal", "message": "No kernel manager (cannot interrupt attached kernel)."})
+        send({"type": "error_internal", "message": "No kernel connected."})
 
 
 def cmd_shutdown(_data: dict) -> None:


### PR DESCRIPTION
## Summary

- Migrate all deprecated `nvim_buf_set_option`/`nvim_buf_get_option`/`nvim_win_set_option` calls to `vim.bo[]`/`vim.wo[]` across core modules
- Migrate `vim.loop.now()` to `vim.uv.now()` in kernel timing code
- Consolidate cell ID generation to use `notebook.gen_cell_id()` consistently instead of mixed `utils.uid()` in add/duplicate/paste/split operations
- Preserve `nbformat_minor` from parsed notebooks instead of always hardcoding `4`/`5` on save
- Extract `setup_win_options()` and add `BufWinEnter` autocmd to apply window options for session-restore and `:badd` buffers
- Add 30-second retry limit to kernel auto-start polling to prevent infinite loops
- Forward `connection_dir` config to kernel attach command

## Test plan

- [ ] Open a notebook, verify cell rendering and borders display correctly
- [ ] Add/delete/duplicate/paste/split cells - verify new cells get proper IDs
- [ ] Save and reopen - verify `nbformat_minor` is preserved (not reset to 5)
- [ ] Start kernel, execute cells - verify elapsed time and status display
- [ ] Open notebook via session restore (`:mksession` / `:source`) - verify conceallevel and signcolumn apply
- [ ] Test auto-start with no kernel available - verify it times out after 30s instead of polling forever
- [ ] Attach to existing kernel with `connection_dir` config set - verify it is forwarded