### PR TITLE
fix: resolve bugs #185-#194 - deprecated APIs, kernel fixes, markdown integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ rendering, full Vim modal editing, live kernel execution, and inline output.
   set-option -g focus-events on
   ```
 
-**Optional - richer markdown cells**
-
-- [render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim)
-
 **Optional - completion**
 
 - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
@@ -104,7 +100,6 @@ return {
           image = { enabled = true },
         },
       },
-      { "MeanderingProgrammer/render-markdown.nvim", opts = {} },
       { "hrsh7th/nvim-cmp" },
       { "nvim-tree/nvim-web-devicons" },
     },

--- a/lua/ipynb/kernel/completion.lua
+++ b/lua/ipynb/kernel/completion.lua
@@ -85,8 +85,7 @@ function M.omnifunc(findstart, base)
     result = msg
   end)
 
-  -- Block until the kernel replies, up to 1.5 s (non-interactive safe).
-  vim.wait(1500, function()
+  vim.wait(500, function()
     return result ~= nil
   end, 10)
 
@@ -163,7 +162,7 @@ end
 ---@param bufnr integer
 function M.attach(bufnr)
   -- Set omnifunc so <C-x><C-o> works without any extra plugins.
-  vim.api.nvim_buf_set_option(bufnr, "omnifunc", "v:lua.require'ipynb.kernel.completion'.omnifunc")
+  vim.bo[bufnr].omnifunc = "v:lua.require'ipynb.kernel.completion'.omnifunc"
 
   -- Register nvim-cmp source once if cmp is available.
   local ok, cmp = pcall(require, "cmp")

--- a/lua/ipynb/ui/inspector.lua
+++ b/lua/ipynb/ui/inspector.lua
@@ -216,8 +216,8 @@ function M.open(bufnr)
 
     local ibuf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_lines(ibuf, 0, -1, false, lines)
-    vim.api.nvim_buf_set_option(ibuf, "modifiable", false)
-    vim.api.nvim_buf_set_option(ibuf, "buftype", "nofile")
+    vim.bo[ibuf].modifiable = false
+    vim.bo[ibuf].buftype = "nofile"
 
     highlight_inspector_buf(ibuf, line_map)
 
@@ -289,8 +289,8 @@ function M.inspect_var(bufnr, var_name)
 
     local dbuf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_lines(dbuf, 0, -1, false, lines)
-    vim.api.nvim_buf_set_option(dbuf, "modifiable", false)
-    vim.api.nvim_buf_set_option(dbuf, "filetype", "markdown")
+    vim.bo[dbuf].modifiable = false
+    vim.bo[dbuf].filetype = "markdown"
 
     local dwin = vim.api.nvim_open_win(dbuf, true, {
       relative = "editor",

--- a/lua/ipynb/ui/keymaps.lua
+++ b/lua/ipynb/ui/keymaps.lua
@@ -272,8 +272,8 @@ function M.show_help()
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-  vim.api.nvim_buf_set_option(buf, "modifiable", false)
-  vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].buftype = "nofile"
 
   local width = math.min(44, vim.o.columns - 4)
   local height = math.min(#lines, vim.o.lines - 4)

--- a/lua/ipynb/ui/markdown.lua
+++ b/lua/ipynb/ui/markdown.lua
@@ -280,16 +280,9 @@ function M.render(bufnr)
   define_highlights()
   vim.api.nvim_buf_clear_namespace(bufnr, NS, 0, -1)
 
-  -- Try render-markdown.nvim first (much richer output).
-  if require("ipynb.utils").has_plugin("render-markdown") then
-    -- render-markdown.nvim works on markdown buffers; we enable it
-    -- selectively per-buffer by calling its API if available.
-    local ok, rm = pcall(require, "render-markdown")
-    if ok and rm.enable then
-      pcall(rm.enable)
-      return
-    end
-  end
+  -- render-markdown.nvim integration removed: it applies decorations to the
+  -- entire buffer (including code cells) because it expects a pure markdown
+  -- filetype. The built-in decorator below is cell-aware.
 
   local ns = cell.namespace()
   local cells = cell.get_cells(bufnr)

--- a/python/kernel_bridge.py
+++ b/python/kernel_bridge.py
@@ -337,9 +337,10 @@ def cmd_attach(data: dict) -> None:
     """Attach to an already-running kernel via its connection file."""
     global _kc
     cf = data.get("connection_file")
+    conn_dir = data.get("connection_dir")
     try:
         if not cf:
-            cf = find_connection_file()
+            cf = find_connection_file(path=conn_dir) if conn_dir else find_connection_file()
         _kc = BlockingKernelClient(connection_file=cf)
         _kc.load_connection_file()
         _kc.start_channels()


### PR DESCRIPTION
## Summary

- Migrate all deprecated `nvim_buf_set_option` / `nvim_win_set_option` calls to `vim.bo[]` / `vim.wo[]` across 6 files (#186)
- Export `gen_cell_id` from `notebook.lua` and use it in `cell.lua` for nbformat-compliant IDs (#185)
- Migrate `vim.loop` to `vim.uv` for Neovim 0.10+ compatibility (#187)
- Wire `connection_dir` config to `find_connection_file(path=)` in kernel_bridge.py (#188)
- Add `BufWinEnter` autocmd to apply window options when buffer is loaded in background (#190)
- Remove render-markdown.nvim integration that applied decorations to entire buffer including code cells (#191)
- Add retry limit (60 retries / 30s) to `_await_and_run` polling loop (#192)
- Reduce omnifunc blocking timeout from 1500ms to 500ms (#193)
- Preserve `nbformat_minor` from parsed notebook instead of hardcoding to 5 (#194)
- Send kernel interrupt via control channel for attached kernels
- Apply stylua formatting to kernel/init.lua

## Test plan

- [ ] Open a notebook and verify cell borders render correctly
- [ ] Run a cell and verify kernel execution works
- [ ] Verify `<C-x><C-o>` completion responds within 500ms
- [ ] Attach to existing kernel with `connection_dir` configured
- [ ] Open notebook in background split and verify window options apply
- [ ] Save notebook and verify `nbformat_minor` matches original value
- [ ] Verify markdown cells use built-in decorator (no render-markdown.nvim)
- [ ] CI passes (lint + format-check + test)