### PR TITLE
feat: pretty-print saved .ipynb JSON for git-friendly diffs

### DIFF
--- a/lua/ipynb/core/notebook.lua
+++ b/lua/ipynb/core/notebook.lua
@@ -42,6 +42,72 @@ local function gen_cell_id()
   return string.format("%08x", math.random(0, 0xFFFFFFFF))
 end
 
+-- ── JSON pretty-printer (1-space indent, Jupyter-compatible) ─────────────────
+
+--- Encode a Lua value as a JSON string with 1-space indentation.
+--- Matches Jupyter's nbformat output: sorted keys, 1-space indent, trailing newline.
+---@param value any
+---@param indent integer
+---@return string
+local function json_encode_pretty(value, indent)
+  indent = indent or 0
+  local t = type(value)
+
+  if value == vim.NIL then
+    return "null"
+  elseif t == "boolean" then
+    return value and "true" or "false"
+  elseif t == "number" then
+    if value ~= value then
+      return "NaN"
+    end
+    if value == math.huge then
+      return "Infinity"
+    end
+    if value == -math.huge then
+      return "-Infinity"
+    end
+    if value == math.floor(value) then
+      return string.format("%d", value)
+    end
+    return tostring(value)
+  elseif t == "string" then
+    return vim.json.encode(value)
+  elseif t == "table" then
+    if (vim.islist or vim.tbl_islist)(value) then
+      if #value == 0 then
+        return "[]"
+      end
+      local items = {}
+      local child_indent = indent + 1
+      local prefix = string.rep(" ", child_indent)
+      for _, v in ipairs(value) do
+        items[#items + 1] = prefix .. json_encode_pretty(v, child_indent)
+      end
+      return "[\n" .. table.concat(items, ",\n") .. "\n" .. string.rep(" ", indent) .. "]"
+    else
+      local keys = {}
+      for k in pairs(value) do
+        keys[#keys + 1] = k
+      end
+      if #keys == 0 then
+        return "{}"
+      end
+      table.sort(keys)
+      local items = {}
+      local child_indent = indent + 1
+      local prefix = string.rep(" ", child_indent)
+      for _, k in ipairs(keys) do
+        local encoded_key = vim.json.encode(k)
+        local encoded_val = json_encode_pretty(value[k], child_indent)
+        items[#items + 1] = prefix .. encoded_key .. ": " .. encoded_val
+      end
+      return "{\n" .. table.concat(items, ",\n") .. "\n" .. string.rep(" ", indent) .. "}"
+    end
+  end
+  return "null"
+end
+
 -- ── Parsing ───────────────────────────────────────────────────────────────────
 
 --- Parse a raw notebook JSON table into the internal Notebook structure.
@@ -133,7 +199,7 @@ function M.save(notebook)
     }
     if cell.cell_type == "code" then
       rc.outputs = cell.outputs or {}
-      rc.execution_count = cell.execution_count
+      rc.execution_count = cell.execution_count or vim.NIL
     end
     raw_cells[#raw_cells + 1] = rc
   end
@@ -145,15 +211,12 @@ function M.save(notebook)
     cells = raw_cells,
   }
 
-  local ok_enc, json = pcall(vim.json.encode, raw)
+  local ok_enc, json = pcall(json_encode_pretty, raw, 0)
   if not ok_enc then
     return false, "JSON encoding failed: " .. tostring(json)
   end
 
-  -- Pretty-print: vim.json.encode produces compact JSON; decode + re-encode
-  -- is not available in all Neovim versions, so we leave it compact.
-  -- Users can run `python3 -m json.tool` externally if they want indented output.
-  local ok_write, werr = utils.write_file(notebook.path, json)
+  local ok_write, werr = utils.write_file(notebook.path, json .. "\n")
   if not ok_write then
     return false, "cannot write file: " .. (werr or notebook.path)
   end

--- a/test/notebook_spec.lua
+++ b/test/notebook_spec.lua
@@ -207,5 +207,39 @@ describe("ipynb.notebook", function()
       assert.are.equal("markdown", notebook2.cells[2].cell_type)
       os.remove(tmp)
     end)
+
+    it("saves with 1-space indented JSON for git-friendly diffs", function()
+      local tmp = os.tmpname() .. ".ipynb"
+      local raw = make_raw_nb({ code_cell("x=1", "aabbccdd") })
+      local notebook = nb.parse(raw, tmp)
+      nb.save(notebook)
+
+      local f = io.open(tmp, "r")
+      local content = f:read("*a")
+      f:close()
+
+      assert.is_truthy(content:match("^\n"), "expected top-level opening brace")
+      assert.is_truthy(content:match('\n "cells":'), "expected 1-space indented keys")
+      assert.is_truthy(content:match('\n  "cell_type":'), "expected 2-space indent for cell fields")
+      assert.is_truthy(content:match("\n$"), "expected trailing newline")
+      assert.is_falsy(content:match("^{[^\n]"), "expected multi-line, not compact JSON")
+
+      os.remove(tmp)
+    end)
+
+    it("saves empty metadata as {} not multi-line", function()
+      local tmp = os.tmpname() .. ".ipynb"
+      local raw = make_raw_nb({ code_cell("x=1", "aabbccdd") })
+      local notebook = nb.parse(raw, tmp)
+      nb.save(notebook)
+
+      local f = io.open(tmp, "r")
+      local content = f:read("*a")
+      f:close()
+
+      assert.is_truthy(content:match('"metadata": {}'), "empty metadata should be compact {}")
+
+      os.remove(tmp)
+    end)
   end)
 end)

--- a/test/notebook_spec.lua
+++ b/test/notebook_spec.lua
@@ -218,11 +218,20 @@ describe("ipynb.notebook", function()
       local content = f:read("*a")
       f:close()
 
-      assert.is_truthy(content:match("^\n"), "expected top-level opening brace")
-      assert.is_truthy(content:match('\n "cells":'), "expected 1-space indented keys")
-      assert.is_truthy(content:match('\n  "cell_type":'), "expected 2-space indent for cell fields")
-      assert.is_truthy(content:match("\n$"), "expected trailing newline")
-      assert.is_falsy(content:match("^{[^\n]"), "expected multi-line, not compact JSON")
+      local lines = vim.split(content, "\n", { plain = true })
+      assert.are.equal("{", lines[1], "expected top-level opening brace on first line")
+      assert.is_truthy(lines[2]:match('^ "cells":'), "expected 1-space indented keys")
+
+      local has_cell_type = false
+      for _, line in ipairs(lines) do
+        if line:match('^  "cell_type":') then
+          has_cell_type = true
+          break
+        end
+      end
+      assert.is_true(has_cell_type, "expected 2-space indent for cell fields")
+      assert.are.equal("", lines[#lines], "expected trailing newline")
+      assert.are.equal("}", lines[#lines - 1], "expected closing brace on last content line")
 
       os.remove(tmp)
     end)
@@ -237,7 +246,14 @@ describe("ipynb.notebook", function()
       local content = f:read("*a")
       f:close()
 
-      assert.is_truthy(content:match('"metadata": {}'), "empty metadata should be compact {}")
+      local has_compact_metadata = false
+      for line in content:gmatch("[^\n]+") do
+        if line:match('"metadata": {}') then
+          has_compact_metadata = true
+          break
+        end
+      end
+      assert.is_true(has_compact_metadata, "empty metadata should be compact {}")
 
       os.remove(tmp)
     end)


### PR DESCRIPTION
## Summary

- Replace compact single-line JSON output with 1-space indented pretty-print matching Jupyter's nbformat standard
- Sorted keys, empty objects stay compact (`{}`), trailing newline at end of file
- Fix `execution_count` to serialize as `null` instead of being omitted when nil
- Add `vim.islist`/`vim.tbl_islist` compat shim for Neovim 0.9 support

Closes #196

## Test plan

- [ ] `make test` passes (round-trip tests + new pretty-print format assertions)
- [ ] Saved notebooks match Jupyter's formatting (1-space indent, sorted keys)
- [ ] `git diff` on saved notebooks shows per-line changes instead of full-file diff
- [ ] Empty metadata renders as `{}` not multi-line