### PR TITLE
fix(lua): seed math.randomseed in setup for unique cell IDs

### DIFF
--- a/lua/ipynb/init.lua
+++ b/lua/ipynb/init.lua
@@ -31,6 +31,9 @@ function M.setup(opts)
   end
   _setup_done = true
 
+  -- Seed the RNG so gen_cell_id() produces unique IDs across sessions.
+  math.randomseed(os.time() + (vim.uv or vim.loop).now())
+
   -- Merge user options into defaults.
   require("ipynb.config").setup(opts)
 


### PR DESCRIPTION
## Summary

- Seed `math.randomseed` with `os.time() + vim.uv.now()` in `setup()` so that `gen_cell_id()` produces unique cell IDs across Neovim sessions
- Without seeding, LuaJIT restarts the same random sequence each session, causing duplicate cell IDs when cells are added in the same order across sessions

Closes #230

## Test plan

- [ ] Open two separate Neovim sessions, create new cells in each, verify cell IDs differ
- [ ] Existing notebooks retain their original cell IDs on load
- [ ] CI passes (lint, format, test)