### PR TITLE
fix(lua): undo reverts cell execution output and plots

### DIFF
--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -226,6 +226,8 @@ local function push_undo(bufnr, cursor_idx)
   state.redo_stack = {}
 end
 
+M.push_undo = push_undo
+
 --- Undo the last structural cell operation.
 ---@param bufnr integer
 ---@return boolean  true if a notebook-level undo was performed

--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -591,6 +591,9 @@ function M.run_current_cell(bufnr)
     return
   end
 
+  local _, cur_idx = cell.cell_at_cursor(bufnr)
+  cell.push_undo(bufnr, cur_idx)
+
   clear_cell_output(bufnr, cs)
 
   local mid = next_msg_id(bufnr)
@@ -638,6 +641,8 @@ function M.run_all(bufnr)
     utils.warn("No kernel running.")
     return
   end
+  local _, cur_idx = cell.cell_at_cursor(bufnr)
+  cell.push_undo(bufnr, cur_idx)
   for _, cs in ipairs(cells) do
     if cs.cell_type == "code" then
       clear_cell_output(bufnr, cs)
@@ -662,6 +667,7 @@ function M.run_all_above(bufnr)
     utils.warn("No kernel running.")
     return
   end
+  cell.push_undo(bufnr, idx)
   for _, entry in ipairs(cell.cells_above(bufnr, idx)) do
     local cs = entry.cell_state
     if cs.cell_type == "code" then
@@ -688,6 +694,7 @@ function M.run_all_below(bufnr)
     utils.warn("No kernel running.")
     return
   end
+  cell.push_undo(bufnr, idx)
   for i = idx, #cells do
     local cs = cells[i]
     if cs.cell_type == "code" then


### PR DESCRIPTION
## Summary

- Export `push_undo` from `cell.lua` so the kernel module can snapshot state before execution
- Call `push_undo` before `clear_cell_output` in `run_current_cell`, `run_all`, `run_all_above`, and `run_all_below` so that pressing `u` after execution restores the previous output (including plots)
- Batch operations (`run_all*`) push a single undo snapshot, not one per cell

Closes #233

## Test plan

- [ ] Execute a code cell that produces output, press `u` - previous output is restored
- [ ] Execute a cell that produces a plot, press `u` - plot is removed and prior state restored
- [ ] Run all cells, press `u` - all outputs revert in one undo step
- [ ] Text editing undo (`u` on typed text) still works as before
- [ ] Structural undo (delete cell, `u`) still works as before
- [ ] CI passes (lint, format, test)