### PR TITLE
fix(lua): LSP attaches correctly to notebook buffers

### DIFF
--- a/lua/ipynb/core/notebook_buf.lua
+++ b/lua/ipynb/core/notebook_buf.lua
@@ -96,7 +96,7 @@ local function attach_lsp(bufnr)
   -- this function is called.  pattern= must match the actual filetype so the
   -- correct LSP server attaches (e.g. r_language_server for R notebooks).
   local buf_ft = vim.bo[bufnr].filetype
-  vim.api.nvim_exec_autocmds("FileType", { pattern = buf_ft })
+  vim.api.nvim_exec_autocmds("FileType", { pattern = buf_ft, buffer = bufnr })
 
   -- Strategy 2: attach any already-running LSP client that serves this filetype.
   local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
@@ -184,6 +184,9 @@ function M.open(path, bufnr)
 
   setup_buf_options(bufnr)
   set_buf_name(bufnr, path)
+
+  local ft = require("ipynb.core.notebook").notebook_language(nb)
+  vim.bo[bufnr].filetype = ft
 
   cell.render(bufnr, nb)
   keymaps.attach(bufnr)

--- a/lua/ipynb/kernel/completion.lua
+++ b/lua/ipynb/kernel/completion.lua
@@ -162,7 +162,12 @@ end
 ---@param bufnr integer
 function M.attach(bufnr)
   -- Set omnifunc so <C-x><C-o> works without any extra plugins.
-  vim.bo[bufnr].omnifunc = "v:lua.require'ipynb.kernel.completion'.omnifunc"
+  -- Preserve the LSP omnifunc if an LSP client is already attached.
+  local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
+  local has_lsp = #get_clients({ bufnr = bufnr }) > 0
+  if not has_lsp then
+    vim.bo[bufnr].omnifunc = "v:lua.require'ipynb.kernel.completion'.omnifunc"
+  end
 
   -- Register nvim-cmp source once if cmp is available.
   local ok, cmp = pcall(require, "cmp")


### PR DESCRIPTION
## Summary

- Add `buffer = bufnr` to `nvim_exec_autocmds("FileType")` in `attach_lsp` so lspconfig targets the notebook buffer, not whichever buffer happens to be focused after the double `vim.schedule`
- Set `vim.bo[bufnr].filetype` from notebook metadata in `open()` before `cell.render()`, so lspconfig's `FileType` handler sees the correct language filetype (e.g. `python`) instead of `ipynb` from ftdetect
- Only set kernel `omnifunc` when no LSP client is attached, preserving `vim.lsp.omnifunc` for `<C-x><C-o>` completion

Closes #234

## Test plan

- [ ] Open a `.ipynb` file with pyright/pylsp configured - LSP attaches and shows diagnostics
- [ ] Hover and go-to-definition work in code cells
- [ ] `<C-x><C-o>` routes to LSP completion when LSP is attached
- [ ] `<C-x><C-o>` routes to kernel completion when no LSP is configured
- [ ] Markdown cells do not produce false LSP diagnostics
- [ ] CI passes (lint, format, test)