### PR TITLE
fix(lua): bounds check sync to prevent data loss and save crash

### DIFF
--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -1254,7 +1254,12 @@ function M.sync_sources_from_buf(bufnr, active_idx)
     local sm = vim.api.nvim_buf_get_extmark_by_id(bufnr, NS, cs.start_mark, {})
     if sm and #sm > 0 and sm[1] < line_count then
       if cs.index < 1 or cs.index > nb_len then
-        utils.warn(("sync skipped cell %d: index out of range (notebook has %d cells)"):format(cs.index, nb_len))
+        utils.warn(
+          ("sync skipped cell %d: index out of range (notebook has %d cells)"):format(
+            cs.index,
+            nb_len
+          )
+        )
       else
         local s = sm[1]
         local em = vim.api.nvim_buf_get_extmark_by_id(bufnr, NS, cs.end_mark, {})

--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -1249,15 +1249,20 @@ function M.sync_sources_from_buf(bufnr, active_idx)
     cells_to_sync = state.cells
   end
 
+  local nb_len = #nb.cells
   for _, cs in ipairs(cells_to_sync) do
     local sm = vim.api.nvim_buf_get_extmark_by_id(bufnr, NS, cs.start_mark, {})
-    if sm and #sm > 0 and sm[1] < line_count and nb.cells[cs.index] then
-      local s = sm[1]
-      local em = vim.api.nvim_buf_get_extmark_by_id(bufnr, NS, cs.end_mark, {})
-      local e = (em and #em > 0) and em[1] or s
-      e = math.min(e, line_count - 1)
-      local lines = vim.api.nvim_buf_get_lines(bufnr, s, e + 1, false)
-      nb.cells[cs.index].source = table.concat(lines, "\n")
+    if sm and #sm > 0 and sm[1] < line_count then
+      if cs.index < 1 or cs.index > nb_len then
+        utils.warn(("sync skipped cell %d: index out of range (notebook has %d cells)"):format(cs.index, nb_len))
+      else
+        local s = sm[1]
+        local em = vim.api.nvim_buf_get_extmark_by_id(bufnr, NS, cs.end_mark, {})
+        local e = (em and #em > 0) and em[1] or s
+        e = math.min(e, line_count - 1)
+        local lines = vim.api.nvim_buf_get_lines(bufnr, s, e + 1, false)
+        nb.cells[cs.index].source = table.concat(lines, "\n")
+      end
     end
   end
 end

--- a/lua/ipynb/core/notebook_buf.lua
+++ b/lua/ipynb/core/notebook_buf.lua
@@ -132,7 +132,12 @@ local function sync_all_cells(bufnr)
       local source = cell.get_cell_source(bufnr, cs)
       nb.cells[cs.index].source = source
     else
-      utils.warn(("sync skipped cell %d: index out of range (notebook has %d cells)"):format(cs.index, nb_len))
+      utils.warn(
+        ("sync skipped cell %d: index out of range (notebook has %d cells)"):format(
+          cs.index,
+          nb_len
+        )
+      )
     end
   end
 end

--- a/lua/ipynb/core/notebook_buf.lua
+++ b/lua/ipynb/core/notebook_buf.lua
@@ -126,9 +126,14 @@ local function sync_all_cells(bufnr)
     return
   end
 
+  local nb_len = #nb.cells
   for _, cs in ipairs(cells) do
-    local source = cell.get_cell_source(bufnr, cs)
-    nb.cells[cs.index].source = source
+    if cs.index >= 1 and cs.index <= nb_len then
+      local source = cell.get_cell_source(bufnr, cs)
+      nb.cells[cs.index].source = source
+    else
+      utils.warn(("sync skipped cell %d: index out of range (notebook has %d cells)"):format(cs.index, nb_len))
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

- `sync_sources_from_buf` in `cell.lua` silently skipped cells when `cs.index` exceeded `nb.cells` length after structural undo, causing data loss on save (fixes #213)
- `sync_all_cells` in `notebook_buf.lua` crashed with `attempt to index a nil value` when `cs.index` was out of range after structural recovery, leaving the file unsaved (fixes #215)
- Both now guard with explicit bounds checks and emit `utils.warn` so the user knows when sync was skipped

## Test plan

- [ ] Open notebook, add cell below, type in original cell, undo cell addition, save - verify warning appears and no data loss
- [ ] Rapid add/delete cells then immediate `:w` - verify no crash
- [ ] Normal editing and saving still works without warnings