### PR TITLE
fix(lua): deep copy cells in integrity rebuild to prevent undo corruption

### DIFF
--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -1343,10 +1343,7 @@ function M.check_structural_integrity(bufnr)
       local lines = vim.api.nvim_buf_get_lines(bufnr, s, e + 1, false)
       local orig = nb.cells[cs.index]
       if orig then
-        local rebuilt = {}
-        for k, v in pairs(orig) do
-          rebuilt[k] = v
-        end
+        local rebuilt = vim.deepcopy(orig)
         rebuilt.source = table.concat(lines, "\n")
         new_cells[#new_cells + 1] = rebuilt
       end


### PR DESCRIPTION
## Summary

- Replace shallow copy with `vim.deepcopy` in `check_structural_integrity` cell rebuild to prevent shared `outputs`/`metadata` references between rebuilt cells and undo snapshots
- Without this fix, kernel output mutations after an integrity rebuild would corrupt undo history, making undo restore wrong output

Closes #227

## Test plan

- [ ] Execute a cell that produces output
- [ ] Trigger a structural integrity check (e.g. delete text that crosses a cell boundary)
- [ ] Execute the cell again (new output)
- [ ] Undo the structural operation - verify old output is correctly restored, not the new output