### PR TITLE
fix(lua): use NormalFloat instead of FloatBorder for help window text

### DIFF
--- a/lua/ipynb/ui/keymaps.lua
+++ b/lua/ipynb/ui/keymaps.lua
@@ -299,7 +299,7 @@ function M.show_help()
     end, { buffer = buf, noremap = true, silent = true })
   end
 
-  vim.api.nvim_set_option_value("winhl", "Normal:FloatBorder", { win = win })
+  vim.api.nvim_set_option_value("winhl", "Normal:NormalFloat", { win = win })
 end
 
 return M


### PR DESCRIPTION
## Summary

- Fix help overlay window rendering text in dim FloatBorder color instead of normal foreground
- Change `winhl` mapping from `Normal:FloatBorder` to `Normal:NormalFloat` so help text is readable

Closes #228

## Test plan

- [ ] Open a notebook and press `<leader>jh` to open the help overlay
- [ ] Verify help text renders in normal foreground color, not dim border color
- [ ] Verify the floating window background matches NormalFloat highlight