### PR TITLE
fix(lua): use configured python_path in health check

### DIFF
--- a/lua/ipynb/health.lua
+++ b/lua/ipynb/health.lua
@@ -14,17 +14,19 @@ end
 
 local function check_python()
   vim.health.start("Python runtime")
-  local out = vim.fn.system("python3 --version 2>&1")
+  local cfg = require("ipynb.config").get()
+  local py = cfg.kernel.python_path
+  local out = vim.fn.system(py .. " --version 2>&1")
   local ver = out:match("Python (%d+%.%d+)")
   if not ver then
-    vim.health.error("python3 not found in PATH", { "Install Python >= 3.12" })
+    vim.health.error(py .. " not found in PATH", { "Install Python >= 3.12" })
     return
   end
   local major, minor = ver:match("(%d+)%.(%d+)")
-  if tonumber(major) >= 3 and tonumber(minor) >= 12 then
-    vim.health.ok("python3 " .. ver)
+  if tonumber(major) > 3 or (tonumber(major) == 3 and tonumber(minor) >= 12) then
+    vim.health.ok(py .. " " .. ver)
   else
-    vim.health.warn("python3 " .. ver .. " found; >= 3.12 recommended")
+    vim.health.warn(py .. " " .. ver .. " found; >= 3.12 recommended")
   end
 end
 


### PR DESCRIPTION
## Summary

- Health check now uses `config.kernel.python_path` instead of hardcoded `python3`
- Fix version comparison logic: `(major > 3) or (major == 3 and minor >= 12)` so Python 4.0+ is not falsely rejected

Closes #225

## Test plan

- [ ] Run `:checkhealth ipynb` with default config - should show `python3` version
- [ ] Set `kernel.python_path` to a custom path and run `:checkhealth ipynb` - should use the custom binary
- [ ] Verify version comparison accepts 3.12+, 3.13+, and hypothetical 4.0+