### PR TITLE
fix(lua): re-register highlights after colorscheme change

### DIFF
--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -34,13 +34,7 @@ local NS = vim.api.nvim_create_namespace("ipynb_cells")
 
 -- ── Highlight groups (defined once on first load) ─────────────────────────────
 
-local hl_defined = false
 local function define_highlights()
-  if hl_defined then
-    return
-  end
-  hl_defined = true
-
   -- Cell border colours.
   vim.api.nvim_set_hl(0, "IpynbCellBorder", { fg = "#4a9eff", bold = true })
   vim.api.nvim_set_hl(0, "IpynbCellBorderMd", { fg = "#f9c74f", bold = true })
@@ -1369,5 +1363,7 @@ end
 function M.namespace()
   return NS
 end
+
+M.define_highlights = define_highlights
 
 return M

--- a/lua/ipynb/init.lua
+++ b/lua/ipynb/init.lua
@@ -77,6 +77,23 @@ function M._register_autocmds()
     end,
     desc = "ipynb: save .ipynb notebook",
   })
+
+  vim.api.nvim_create_autocmd("ColorScheme", {
+    group = group,
+    callback = function()
+      require("ipynb.core.cell").define_highlights()
+      require("ipynb.ui.ansi").reset_highlights()
+      local ok_md, md = pcall(require, "ipynb.ui.markdown")
+      if ok_md then
+        md.define_highlights()
+      end
+      local ok_ins, ins = pcall(require, "ipynb.ui.inspector")
+      if ok_ins then
+        ins.define_highlights()
+      end
+    end,
+    desc = "ipynb: re-register highlights after colorscheme change",
+  })
 end
 
 -- ── Convenience public API ────────────────────────────────────────────────────

--- a/lua/ipynb/ui/ansi.lua
+++ b/lua/ipynb/ui/ansi.lua
@@ -273,4 +273,9 @@ function M.has_ansi(text)
   return text:find("\27%[") ~= nil
 end
 
+function M.reset_highlights()
+  _hl_cache = {}
+  _hl_counter = 0
+end
+
 return M

--- a/lua/ipynb/ui/inspector.lua
+++ b/lua/ipynb/ui/inspector.lua
@@ -55,12 +55,7 @@ del __jvim_json, __jvim_skip, __jvim_vars, __jvim_name, __jvim_val, __jvim_type,
 
 -- ── Highlight groups ──────────────────────────────────────────────────────────
 
-local _hl_done = false
 local function define_highlights()
-  if _hl_done then
-    return
-  end
-  _hl_done = true
   vim.api.nvim_set_hl(0, "IpynbInspectorHeader", { fg = "#7aa2f7", bold = true })
   vim.api.nvim_set_hl(0, "IpynbInspectorName", { fg = "#c0caf5" })
   vim.api.nvim_set_hl(0, "IpynbInspectorType", { fg = "#e0af68", italic = true })
@@ -313,5 +308,7 @@ function M.inspect_var(bufnr, var_name)
     end
   end)
 end
+
+M.define_highlights = define_highlights
 
 return M

--- a/lua/ipynb/ui/markdown.lua
+++ b/lua/ipynb/ui/markdown.lua
@@ -30,13 +30,7 @@ local NS = vim.api.nvim_create_namespace("ipynb_markdown")
 
 -- ── Highlights ────────────────────────────────────────────────────────────────
 
-local _hl_done = false
 local function define_highlights()
-  if _hl_done then
-    return
-  end
-  _hl_done = true
-
   vim.api.nvim_set_hl(0, "IpynbMdH1", { fg = "#ff9e64", bold = true, underline = true })
   vim.api.nvim_set_hl(0, "IpynbMdH2", { fg = "#e0af68", bold = true })
   vim.api.nvim_set_hl(0, "IpynbMdH3", { fg = "#9ece6a", bold = true })
@@ -340,5 +334,7 @@ end
 function M.clear(bufnr)
   vim.api.nvim_buf_clear_namespace(bufnr, NS, 0, -1)
 end
+
+M.define_highlights = define_highlights
 
 return M


### PR DESCRIPTION
## Summary

- Remove once-guards (`_hl_done`, `hl_defined`) from highlight definitions in cell.lua, markdown.lua, and inspector.lua - `nvim_set_hl` is already idempotent
- Export `define_highlights()` from cell, markdown, and inspector modules
- Add `reset_highlights()` to ansi.lua to clear its dynamic highlight cache
- Register a `ColorScheme` autocmd in init.lua that re-creates all plugin highlights after theme changes

Closes #221

## Test plan

- [ ] Open a notebook and verify cell borders, markdown decorations, and output colors render correctly
- [ ] Run `:colorscheme desert` (or any other scheme) and verify all ipynb highlights are restored
- [ ] Run a cell with ANSI output, change colorscheme, run another cell - verify ANSI colors still work
- [ ] Open the variable inspector after a colorscheme change - verify highlight groups are correct