### PR TITLE
fix(lua): wait for kernel readiness in batch run functions

### DIFF
--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -632,15 +632,46 @@ function M.run_cell_and_advance(bufnr)
   end
 end
 
+--- Poll until the kernel is idle, then call fn(). Gives up after 30s.
+---@param bufnr integer
+---@param fn function
+local function await_ready_then(bufnr, fn)
+  local retries = 0
+  local max_retries = 60
+  local function poll()
+    local st = get_state(bufnr)
+    if not st.job_id or st.status == "stopped" then
+      return
+    end
+    retries = retries + 1
+    if retries > max_retries then
+      utils.warn("Kernel did not become ready after 30s - aborting")
+      return
+    end
+    if st.status == "idle" then
+      fn()
+    else
+      vim.defer_fn(poll, 500)
+    end
+  end
+  vim.defer_fn(poll, 500)
+end
+
 --- Execute every code cell in the notebook.
 ---@param bufnr integer
 function M.run_all(bufnr)
   local s = get_state(bufnr)
-  local cells = cell.get_cells(bufnr)
   if not s.job_id then
     utils.warn("No kernel running.")
     return
   end
+  if s.status ~= "idle" then
+    await_ready_then(bufnr, function()
+      M.run_all(bufnr)
+    end)
+    return
+  end
+  local cells = cell.get_cells(bufnr)
   local _, cur_idx = cell.cell_at_cursor(bufnr)
   cell.push_undo(bufnr, cur_idx)
   for _, cs in ipairs(cells) do
@@ -667,6 +698,12 @@ function M.run_all_above(bufnr)
     utils.warn("No kernel running.")
     return
   end
+  if s.status ~= "idle" then
+    await_ready_then(bufnr, function()
+      M.run_all_above(bufnr)
+    end)
+    return
+  end
   cell.push_undo(bufnr, idx)
   for _, entry in ipairs(cell.cells_above(bufnr, idx)) do
     local cs = entry.cell_state
@@ -689,11 +726,17 @@ function M.run_all_below(bufnr)
     return
   end
   local s = get_state(bufnr)
-  local cells = cell.get_cells(bufnr)
   if not s.job_id then
     utils.warn("No kernel running.")
     return
   end
+  if s.status ~= "idle" then
+    await_ready_then(bufnr, function()
+      M.run_all_below(bufnr)
+    end)
+    return
+  end
+  local cells = cell.get_cells(bufnr)
   cell.push_undo(bufnr, idx)
   for i = idx, #cells do
     local cs = cells[i]


### PR DESCRIPTION
## Summary

- Add `await_ready_then` helper that polls kernel status until idle (30s timeout)
- `run_all`, `run_all_above`, and `run_all_below` now check `s.status` before enqueuing cells
- If kernel is in "starting" state, batch functions defer until ready instead of flooding error notifications

Closes #226

## Test plan

- [ ] Open a notebook and immediately run `:IpynbRunAll` before kernel is ready - should wait and execute after kernel becomes idle
- [ ] Run `:IpynbRunAll` when kernel is already idle - should execute all cells immediately
- [ ] Run `:IpynbRunAllAbove` / `:IpynbRunAllBelow` during kernel startup - should defer, not flood errors
- [ ] Verify 30s timeout produces a single warning if kernel never becomes ready