### PR TITLE
fix(python): add _pending_lock to prevent IOPub race with execute mapping

### DIFF
--- a/python/kernel_bridge.py
+++ b/python/kernel_bridge.py
@@ -59,6 +59,10 @@ from jupyter_client.blocking import BlockingKernelClient
 # the main stdin-reading thread both call send().
 _stdout_lock = threading.Lock()
 
+# Serialises _kc.execute() + _pending[zmq_id] write so the IOPub thread
+# cannot observe a reply before the mapping exists.
+_pending_lock = threading.Lock()
+
 # ── ANSI escape handling ──────────────────────────────────────────────────────
 # Full strip: removes ALL ANSI escapes (SGR + cursor movement + OSC + charset).
 # Used only for contexts that render plain text (e.g. inspect/documentation).
@@ -173,7 +177,8 @@ def send(msg: dict) -> None:
 
 def _lua_id(zmq_parent_id: str) -> str:
     """Translate a ZMQ parent msg_id to the originating Lua msg_id (or keep as-is)."""
-    return _pending.get(zmq_parent_id, zmq_parent_id)
+    with _pending_lock:
+        return _pending.get(zmq_parent_id, zmq_parent_id)
 
 
 # ── IOPub listener (background thread) ────────────────────────────────────────
@@ -215,8 +220,9 @@ def _process_iopub(msg: dict) -> None:
         state = content.get("execution_state", "")
         send({"type": "status", "state": state, "msg_id": lid})
         # Clean up pending map when the kernel goes back to idle.
-        if state == "idle" and zmq_pid in _pending:
-            del _pending[zmq_pid]
+        with _pending_lock:
+            if state == "idle" and zmq_pid in _pending:
+                del _pending[zmq_pid]
 
     elif msg_type == "stream":
         send({
@@ -379,9 +385,9 @@ def cmd_execute(data: dict) -> None:
     code   = data.get("code", "")
     lua_id = data.get("msg_id", "")
     try:
-        zmq_id = _kc.execute(code, store_history=True)
-        # Register the ZMQ → Lua mapping so the IOPub thread can translate.
-        _pending[zmq_id] = lua_id
+        with _pending_lock:
+            zmq_id = _kc.execute(code, store_history=True)
+            _pending[zmq_id] = lua_id
     except Exception as exc:
         send({"type": "error_internal", "message": f"Execute failed: {exc}"})
 


### PR DESCRIPTION
## Summary

- Add `_pending_lock` (threading.Lock) to serialize `_kc.execute()` + `_pending[zmq_id] = lua_id` writes
- IOPub thread's `_lua_id()` lookup now acquires the same lock, preventing it from reading before the mapping exists
- Cleanup `del _pending[zmq_pid]` also acquires the lock for consistency
- Fixes race where fast kernel replies arrive before the ZMQ-to-Lua mapping is registered, causing output to be silently dropped and cells to stay perpetually "busy"

Closes #211

## Test plan

- [ ] Execute a simple cell (`1+1`) repeatedly on an idle kernel - output should always appear
- [ ] Run multiple cells in quick succession - no cells should get stuck in "busy" state
- [ ] Verify no deadlocks by running a notebook with 10+ cells via `:IpynbRunAll`