### PR TITLE
fix(python): stash non-matching shell replies instead of discarding them

### DIFF
--- a/python/kernel_bridge.py
+++ b/python/kernel_bridge.py
@@ -123,14 +123,23 @@ def _venv_kernel_python() -> Optional[str]:
     return None
 
 
+_shell_stash: list[dict] = []
+
+
 def _get_shell_reply(zmq_id: str, timeout: float = 10.0) -> dict:
     """Fetch the shell reply whose parent msg_id matches zmq_id.
 
     In jupyter_client >= 8.x, KernelClient.complete() and .inspect() return
     the ZMQ msg_id (str) rather than the reply dict.  This helper polls
-    get_shell_msg() until the matching reply arrives, discarding unrelated
-    messages (e.g. execute_reply for a concurrently running cell).
+    get_shell_msg() until the matching reply arrives.  Non-matching messages
+    are stashed and re-checked on the next call so they are never lost.
     """
+    # Check stashed messages first.
+    for i, msg in enumerate(_shell_stash):
+        if msg.get("parent_header", {}).get("msg_id") == zmq_id:
+            _shell_stash.pop(i)
+            return msg.get("content", {})
+
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         remaining = deadline - time.monotonic()
@@ -142,6 +151,7 @@ def _get_shell_reply(zmq_id: str, timeout: float = 10.0) -> dict:
             break
         if reply.get("parent_header", {}).get("msg_id") == zmq_id:
             return reply.get("content", {})
+        _shell_stash.append(reply)
     return {}
 
 


### PR DESCRIPTION
## Summary

- `_get_shell_reply` now stashes non-matching shell messages in `_shell_stash` instead of silently discarding them
- On each call, stashed messages are checked first before polling the shell channel
- Prevents lost `execute_reply` messages when completion/inspect requests overlap with cell execution

Closes #229

## Test plan

- [ ] Run a cell and immediately trigger completion (Ctrl-Space) - cell should still complete execution normally
- [ ] Request inspect documentation while a cell is running - cell output should appear correctly after execution
- [ ] Verify completion and inspect still return results within expected timeout