### PR TITLE
fix(lua): zombie kernel processes on buffer delete and Neovim exit

### DIFF
--- a/lua/ipynb/init.lua
+++ b/lua/ipynb/init.lua
@@ -77,6 +77,17 @@ function M._register_autocmds()
     end,
     desc = "ipynb: save .ipynb notebook",
   })
+
+  vim.api.nvim_create_autocmd("VimLeavePre", {
+    group = group,
+    callback = function()
+      local ok, kernel = pcall(require, "ipynb.kernel")
+      if ok then
+        kernel.stop_all()
+      end
+    end,
+    desc = "ipynb: shut down all kernels before Neovim exits",
+  })
 end
 
 -- ── Convenience public API ────────────────────────────────────────────────────

--- a/lua/ipynb/init.lua
+++ b/lua/ipynb/init.lua
@@ -87,6 +87,8 @@ function M._register_autocmds()
       end
     end,
     desc = "ipynb: shut down all kernels before Neovim exits",
+  })
+
   vim.api.nvim_create_autocmd("ColorScheme", {
     group = group,
     callback = function()

--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -817,9 +817,28 @@ end
 function M.on_buf_delete(bufnr)
   local s = _state[bufnr]
   if s and s.job_id then
-    vim.fn.jobstop(s.job_id)
+    s.status = "stopped"
+    send(bufnr, { cmd = "shutdown" })
+    local job = s.job_id
+    vim.defer_fn(function()
+      pcall(vim.fn.jobstop, job)
+    end, 500)
   end
   _state[bufnr] = nil
+end
+
+--- Gracefully shut down all active kernel bridges.
+--- Called from VimLeavePre to avoid orphaned ipykernel processes.
+function M.stop_all()
+  for bufnr, s in pairs(_state) do
+    if s.job_id then
+      s.status = "stopped"
+      pcall(vim.fn.chansend, s.job_id, vim.fn.json_encode({ cmd = "shutdown" }) .. "\n")
+      pcall(vim.fn.jobwait, { s.job_id }, 1000)
+      pcall(vim.fn.jobstop, s.job_id)
+    end
+    _state[bufnr] = nil
+  end
 end
 
 -- ── Post-render hook: remap stale pending cell_state references ───────────────


### PR DESCRIPTION
## Summary

- `on_buf_delete` was calling `jobstop` directly without sending `{"cmd":"shutdown"}` first, leaving orphaned ipykernel processes. Now sends shutdown with a 500ms grace period before jobstop, matching the existing `M.stop()` pattern.
- Adds `M.stop_all()` which synchronously shuts down all active kernel bridges using `jobwait` (1s timeout per kernel).
- Registers a `VimLeavePre` autocmd that calls `kernel.stop_all()` so all kernels are cleaned up when Neovim exits.

Closes #212

## Test plan

- [ ] Start a kernel with `:IpynbKernelStart`, then `:bd` the buffer - verify no orphaned `ipykernel` process remains (`ps aux | grep ipykernel`)
- [ ] Start kernels in two notebook buffers, quit Neovim with `:qa` - verify both ipykernel processes are terminated
- [ ] Start a kernel, run a cell, then `:bd` - verify no zombie python processes linger
- [ ] Verify normal `:IpynbKernelStop` still works as before