### PR TITLE
fix(lua): cap output store size to prevent memory leak

### DIFF
--- a/lua/ipynb/config.lua
+++ b/lua/ipynb/config.lua
@@ -22,6 +22,7 @@ local M = {}
 ---@field show_execution_count boolean
 ---@field show_elapsed_time boolean
 ---@field output_max_lines integer   Max virt_lines per output block (0 = unlimited)
+---@field output_max_store integer   Max chunks kept per cell in the output store (0 = unlimited)
 
 ---@class BorderChars
 ---@field top_left string
@@ -102,6 +103,7 @@ M.defaults = {
     show_execution_count = true,
     show_elapsed_time = true,
     output_max_lines = 50,
+    output_max_store = 5000,
   },
 
   keymaps = {

--- a/lua/ipynb/kernel/output.lua
+++ b/lua/ipynb/kernel/output.lua
@@ -178,7 +178,15 @@ function M.append(bufnr, cell_state, chunk)
   if not _store[key] then
     _store[key] = {}
   end
-  _store[key][#_store[key] + 1] = chunk
+  local store = _store[key]
+  store[#store + 1] = chunk
+
+  local max_store = config.get().ui.output_max_store
+  if max_store > 0 then
+    while #store > max_store do
+      table.remove(store, 1)
+    end
+  end
 
   M._render(bufnr, cell_state)
 end

--- a/test/output_spec.lua
+++ b/test/output_spec.lua
@@ -20,7 +20,7 @@ describe("ipynb.output", function()
   local function make_config_stub(max_lines)
     return {
       get = function()
-        return { ui = { output_max_lines = max_lines or 50 } }
+        return { ui = { output_max_lines = max_lines or 50, output_max_store = 0 } }
       end,
     }
   end


### PR DESCRIPTION
## Summary

- Adds `ui.output_max_store` config option (default 5000) to limit chunks kept per cell in the output store
- `M.append` now evicts oldest chunks (FIFO) when the store exceeds the limit
- Prevents unbounded memory growth and O(n) render degradation from long-running streaming cells (e.g. training loops)

Closes #224

## Test plan

- [ ] Run a cell with `for i in range(10000): print(f"step {i}")` - verify memory stays bounded and no progressive lag
- [ ] Set `output_max_store = 10` in config, run streaming cell - verify only last ~10 chunks are shown
- [ ] Set `output_max_store = 0` for unlimited - verify no eviction occurs
- [ ] Verify normal short-output cells still render correctly