### PR TITLE
fix(lua): use stable cell_id for output store key

### DIFF
--- a/lua/ipynb/kernel/output.lua
+++ b/lua/ipynb/kernel/output.lua
@@ -35,7 +35,7 @@ local HL = {
 }
 
 -- ── Per-cell output accumulator ───────────────────────────────────────────────
--- Key: bufnr .. ":" .. cell_state.start_mark   (unique per cell per buffer)
+-- Key: bufnr .. ":" .. cell_state.cell_id   (stable across renders)
 -- Value: list of chunk tables
 local _store = {}
 
@@ -51,7 +51,7 @@ local _active = {}
 local _pending = {}
 
 local function cell_key(bufnr, cell_state)
-  return tostring(bufnr) .. ":" .. tostring(cell_state.start_mark)
+  return tostring(bufnr) .. ":" .. tostring(cell_state.cell_id)
 end
 
 --- Return accumulated chunks for a cell (empty list if none).

--- a/test/output_spec.lua
+++ b/test/output_spec.lua
@@ -57,7 +57,7 @@ describe("ipynb.output", function()
   end)
 
   local function fake_cell(mark_id)
-    return { start_mark = mark_id or 1 }
+    return { start_mark = mark_id or 1, cell_id = "cell_" .. tostring(mark_id or 1) }
   end
 
   -- ── M.get_chunks() ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Changes `cell_key()` in output.lua from `cell_state.start_mark` (ephemeral extmark id that changes every render) to `cell_state.cell_id` (stable notebook cell identifier)
- Prevents output chunks from being orphaned when structural edits trigger re-renders during cell execution
- Eliminates associated memory leak from unreachable store entries

Closes #217

## Test plan

- [ ] Execute a cell with streaming output (e.g. `for i in range(100): print(i); import time; time.sleep(0.1)`)
- [ ] While output is streaming, add a cell above the executing cell
- [ ] Verify all prior output is preserved and new output continues appending
- [ ] Verify `clear_output` still works after structural edits mid-execution