### PR TITLE
fix(python): run complete/inspect in background threads

### DIFF
--- a/python/kernel_bridge.py
+++ b/python/kernel_bridge.py
@@ -390,37 +390,45 @@ def cmd_complete(data: dict) -> None:
     if _kc is None:
         send({"type": "error_internal", "message": "No kernel connected."})
         return
-    code       = data.get("code", "")
-    cursor_pos = data.get("cursor_pos", len(code))
-    lua_id     = data.get("msg_id", "")
-    try:
-        zmq_id  = _kc.complete(code, cursor_pos)
-        content = _get_shell_reply(zmq_id)
-        send({
-            "type":         "complete",
-            "matches":      content.get("matches", []),
-            "cursor_start": content.get("cursor_start", cursor_pos),
-            "cursor_end":   content.get("cursor_end",   cursor_pos),
-            "msg_id":       lua_id,
-        })
-    except Exception as exc:
-        send({"type": "error_internal", "message": f"Complete failed: {exc}"})
+
+    def _do_complete() -> None:
+        code       = data.get("code", "")
+        cursor_pos = data.get("cursor_pos", len(code))
+        lua_id     = data.get("msg_id", "")
+        try:
+            zmq_id  = _kc.complete(code, cursor_pos)
+            content = _get_shell_reply(zmq_id)
+            send({
+                "type":         "complete",
+                "matches":      content.get("matches", []),
+                "cursor_start": content.get("cursor_start", cursor_pos),
+                "cursor_end":   content.get("cursor_end",   cursor_pos),
+                "msg_id":       lua_id,
+            })
+        except Exception as exc:
+            send({"type": "error_internal", "message": f"Complete failed: {exc}"})
+
+    threading.Thread(target=_do_complete, daemon=True).start()
 
 
 def cmd_inspect(data: dict) -> None:
     if _kc is None:
         send({"type": "error_internal", "message": "No kernel connected."})
         return
-    code       = data.get("code", "")
-    cursor_pos = data.get("cursor_pos", len(code))
-    lua_id     = data.get("msg_id", "")
-    try:
-        zmq_id   = _kc.inspect(code, cursor_pos)
-        content  = _get_shell_reply(zmq_id)
-        raw_text = content.get("data", {}).get("text/plain", "")
-        send({"type": "inspect", "text": _strip_ansi(raw_text), "msg_id": lua_id})
-    except Exception as exc:
-        send({"type": "error_internal", "message": f"Inspect failed: {exc}"})
+
+    def _do_inspect() -> None:
+        code       = data.get("code", "")
+        cursor_pos = data.get("cursor_pos", len(code))
+        lua_id     = data.get("msg_id", "")
+        try:
+            zmq_id   = _kc.inspect(code, cursor_pos)
+            content  = _get_shell_reply(zmq_id)
+            raw_text = content.get("data", {}).get("text/plain", "")
+            send({"type": "inspect", "text": _strip_ansi(raw_text), "msg_id": lua_id})
+        except Exception as exc:
+            send({"type": "error_internal", "message": f"Inspect failed: {exc}"})
+
+    threading.Thread(target=_do_inspect, daemon=True).start()
 
 
 def cmd_interrupt(_data: dict) -> None:


### PR DESCRIPTION
## Summary

- `cmd_complete` and `cmd_inspect` called `_get_shell_reply()` synchronously on the main stdin-reading thread, blocking all command processing for up to 10 seconds
- Now both handlers spawn a daemon thread for the blocking shell reply wait
- The main loop stays responsive to interrupt, execute, and shutdown commands during completion/inspection

Closes #216

## Test plan

- [ ] Trigger completion (omnifunc or nvim-cmp) during cell execution - verify interrupt still works immediately
- [ ] Trigger inspect (hover documentation) - verify other commands are not delayed
- [ ] Test completion with a slow kernel - verify results still arrive correctly
- [ ] Rapid completion requests in succession - verify no crashes or mixed-up results