### PR TITLE
fix(config): use existing action versions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v4
         with: { fetch-depth: 0, ref: "${{ github.ref_name }}" }
       - name: Force release branch to workflow SHA
         run: git reset --hard ${{ github.sha }}
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v5
         with: { python-version: "3.12" }
       - uses: python-semantic-release/python-semantic-release@v10.5.3
         with:


### PR DESCRIPTION
## Summary

- Fix release workflow referencing non-existent action versions (`actions/checkout@v6.0.2` and `actions/setup-python@v6.2.0`)
- Downgrade to `actions/checkout@v4` and `actions/setup-python@v5` (actual latest major versions)
- The other parts of #204 (python-check and headless-test CI jobs) are already implemented in ci.yml

Closes #204

## Test plan

- [ ] Verify release workflow runs successfully on next push to main
- [ ] Confirm CI pipeline still passes with existing python-check and headless-test jobs