### PR TITLE
docs: update README config and fix pyproject description

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,16 @@ or `setup()` to override.
 
 ```lua
 require("ipynb").setup({
+  cell = {
+    highlight_cell = true,       -- highlight the active cell background
+    hl_group       = "CursorLine",
+  },
   kernel = {
     default_kernel   = "python3",
     auto_start       = true,       -- start kernel automatically on first run
     python_path      = "python3",  -- fallback if uv venv is not found
     restart_on_crash = false,      -- auto-restart kernel after unexpected crash
+    connection_dir   = "~/.local/share/jupyter/runtime",
   },
   ui = {
     show_execution_count = true,
@@ -289,7 +294,8 @@ require("ipynb").setup({
     merge_cell          = "<leader>cm",
   },
   notebook = {
-    auto_save = false,
+    auto_save            = false,
+    default_kernel_name  = "python3",
   },
 })
 ```

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ipynb"
 version = "0.1.0"
-description = "Add your description here"
+description = "ZMQ kernel bridge daemon for ipynb.nvim - Jupyter kernel management via JSON-line stdio"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

- Add missing config options to README: `cell` section (`highlight_cell`, `hl_group`), `kernel.connection_dir`, `notebook.default_kernel_name`
- Fix placeholder description in `python/pyproject.toml` ("Add your description here" -> actual description)

Closes #201

## Test plan

- [ ] README config block matches actual defaults in config.lua
- [ ] python/pyproject.toml description is accurate