### PR TITLE
feat: :IpynbGotoCell N command for jumping to cell by index

### DIFF
--- a/lua/ipynb/core/cell.lua
+++ b/lua/ipynb/core/cell.lua
@@ -580,6 +580,20 @@ function M.goto_prev_cell(bufnr)
   vim.api.nvim_win_set_cursor(0, { s + 1, 0 })
 end
 
+--- Jump to cell N (1-based index).
+---@param bufnr integer
+---@param n integer
+function M.goto_cell(bufnr, n)
+  local state = get_state(bufnr)
+  if n < 1 or n > #state.cells then
+    utils.warn("Cell " .. n .. " does not exist (notebook has " .. #state.cells .. " cells)")
+    return
+  end
+  local cs = state.cells[n]
+  local s, _ = cell_line_range(bufnr, cs)
+  vim.api.nvim_win_set_cursor(0, { s + 1, 0 })
+end
+
 -- ── Cell source extraction ────────────────────────────────────────────────────
 
 --- Return the current source text of a cell as a string, read from the buffer.

--- a/lua/ipynb/ui/commands.lua
+++ b/lua/ipynb/ui/commands.lua
@@ -250,6 +250,22 @@ function M.setup()
     end
   end, { desc = "Merge the current cell with the cell below" })
 
+  -- ── Navigation commands ─────────────────────────────────────────────────
+
+  vim.api.nvim_create_user_command("IpynbGotoCell", function(args)
+    local cell_mod = require("ipynb.core.cell")
+    local bufnr = vim.api.nvim_get_current_buf()
+    local n = tonumber(args.args)
+    if not n then
+      vim.notify("Usage: :IpynbGotoCell <number>", vim.log.levels.WARN)
+      return
+    end
+    cell_mod.goto_cell(bufnr, n)
+  end, {
+    nargs = 1,
+    desc = "Jump to cell N (1-based index)",
+  })
+
   -- ── Output commands ───────────────────────────────────────────────────
 
   vim.api.nvim_create_user_command("IpynbClearOutput", function()


### PR DESCRIPTION
## Summary

- Add `M.goto_cell(bufnr, n)` function in `core/cell.lua` for jumping to any cell by 1-based index
- Add `:IpynbGotoCell N` user command in `ui/commands.lua`
- Shows a warning if the cell number is out of range

Closes #167

## Test plan

- [ ] `:IpynbGotoCell 1` jumps to first cell
- [ ] `:IpynbGotoCell 5` jumps to fifth cell (if it exists)
- [ ] `:IpynbGotoCell 999` shows "does not exist" warning
- [ ] `:IpynbGotoCell` without argument shows usage warning