### PR TITLE
feat: :IpynbRunSelection for executing visual selection

### DIFF
--- a/lua/ipynb/kernel/init.lua
+++ b/lua/ipynb/kernel/init.lua
@@ -635,6 +635,46 @@ function M.run_cell_and_advance(bufnr)
   end
 end
 
+--- Execute the visually selected lines within the current cell.
+--- Output is attached to the cell the cursor is in.
+---@param bufnr integer
+function M.run_selection(bufnr)
+  local cs, _ = cell.cell_at_cursor(bufnr)
+  if not cs then
+    utils.warn("Cursor is not inside a cell.")
+    return
+  end
+  if cs.cell_type ~= "code" then
+    utils.info("Not a code cell - skipping execution.")
+    return
+  end
+
+  local s = get_state(bufnr)
+  if not s.job_id then
+    utils.warn("No kernel running. Use :IpynbKernelStart.")
+    return
+  end
+
+  local start_line = vim.fn.line("'<") - 1
+  local end_line = vim.fn.line("'>") - 1
+  local lines = vim.api.nvim_buf_get_lines(bufnr, start_line, end_line + 1, false)
+  local code = table.concat(lines, "\n")
+
+  if vim.trim(code) == "" then
+    utils.info("Selection is empty.")
+    return
+  end
+
+  clear_cell_output(bufnr, cs)
+
+  local mid = next_msg_id(bufnr)
+  s.pending[mid] = { cell_state = cs, cell_id = cs.cell_id, bufnr = bufnr, start_ms = vim.uv.now() }
+
+  cell.update_status(bufnr, cs, "busy", nil)
+  utils.info("Executing selection [" .. mid .. "]: " .. vim.trim(code):sub(1, 40))
+  send(bufnr, { cmd = "execute", code = code, msg_id = mid })
+end
+
 --- Poll until the kernel is idle, then call fn(). Gives up after 30s.
 ---@param bufnr integer
 ---@param fn function

--- a/lua/ipynb/ui/commands.lua
+++ b/lua/ipynb/ui/commands.lua
@@ -122,6 +122,14 @@ function M.setup()
     end
   end, { desc = "Execute all cells below the cursor" })
 
+  vim.api.nvim_create_user_command("IpynbRunSelection", function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local ok, kernel = pcall(require, "ipynb.kernel")
+    if ok then
+      kernel.run_selection(bufnr)
+    end
+  end, { range = true, desc = "Execute the visually selected lines" })
+
   -- ── Cell editing commands ──────────────────────────────────────────────
 
   vim.api.nvim_create_user_command("IpynbCellAdd", function()


### PR DESCRIPTION
## Summary

- Add `M.run_selection(bufnr)` in `kernel/init.lua` - executes visually selected lines within a code cell
- Add `:IpynbRunSelection` command (range-aware) in `ui/commands.lua`
- Output is displayed against the cell the cursor is in (same as full cell execution)
- Validates: must be in a code cell, kernel must be running, selection must be non-empty

Closes #165

## Test plan

- [ ] Select lines in a code cell with visual mode, run `:IpynbRunSelection`
- [ ] Output appears below the cell
- [ ] Running outside a cell shows warning
- [ ] Running in a markdown cell shows info message
- [ ] Running with no kernel shows "No kernel running" warning